### PR TITLE
fix: 改进 dataZoom 的性能

### DIFF
--- a/packages/core/src/components/uni-echarts/uni-echarts.vue
+++ b/packages/core/src/components/uni-echarts/uni-echarts.vue
@@ -39,7 +39,7 @@
       type="2d"
       :disable-scroll="props.disableScroll"
       @touchstart="touch.onStart"
-      @touchmove="touch.onMove"
+      @touchmove="throttledMove"
       @touchend="touch.onEnd"></canvas>
 
     <canvas
@@ -49,7 +49,7 @@
       :canvas-id="canvasId"
       :disable-scroll="props.disableScroll"
       @touchstart="touch.onStart"
-      @touchmove="touch.onMove"
+      @touchmove="throttledMove"
       @touchend="touch.onEnd"></canvas>
 
     <view
@@ -59,7 +59,7 @@
       @mousemove="touch.onMove"
       @mouseup="touch.onEnd"
       @touchstart="touch.onStart"
-      @touchmove="touch.onMove"
+      @touchmove="throttledMove"
       @touchend="touch.onEnd"></view>
 
     <slot></slot>
@@ -196,6 +196,22 @@ const touch = useEchartsTouch({
   canvasRect,
   getTouch
 });
+
+const canvasNode = computed(() => chart.value.getDom().canvasNode);
+
+let ticking = false;
+
+function throttledMove(event) {
+  if (ticking) {
+    return;
+  }
+
+  ticking = true;
+  canvasNode.value.requestAnimationFrame(() => {
+    touch.onMove(event);
+    ticking = false;
+  });
+}
 
 // #ifdef WEB
 


### PR DESCRIPTION
利用 `requestanimationFrame()` 限制 `touch.onMove()` 调用频率。 尝试过 WXS 方式，效果不明显，可能因为无法减少视图层到逻辑层的通信量

参考文档：
https://developers.weixin.qq.com/miniprogram/dev/framework/view/interactive-animation.html

相关 issue：#12 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **性能优化**
  * 优化触摸移动事件的处理，提升触控操作的流畅性和响应速度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->