### PR TITLE
fix: 限制 touchemove 事件处理方法调用频率

### DIFF
--- a/packages/core/src/components/uni-echarts/uni-echarts.vue
+++ b/packages/core/src/components/uni-echarts/uni-echarts.vue
@@ -404,7 +404,7 @@ async function resize(options = {}) {
 
 function cleanup() {
   if (rafToken !== null) {
-    cancelFrame(rafToken);
+    cancelFrame.value(rafToken);
     rafToken = null;
     lastMoveEvent = null;
     ticking = false;

--- a/packages/core/src/components/uni-echarts/uni-echarts.vue
+++ b/packages/core/src/components/uni-echarts/uni-echarts.vue
@@ -205,7 +205,7 @@ let lastMoveEvent = null;
 let rafToken = null;
 
 function throttledMove(event) {
-  lastMoveEvent = event;
+  lastMoveEvent = { ...event };
   if (ticking) {
     return;
   }
@@ -404,7 +404,7 @@ async function resize(options = {}) {
 
 function cleanup() {
   if (rafToken !== null) {
-    cancelFrame.value(rafToken);
+    cancelFrame.value?.(rafToken);
     rafToken = null;
     lastMoveEvent = null;
     ticking = false;

--- a/packages/core/src/components/uni-echarts/uni-echarts.vue
+++ b/packages/core/src/components/uni-echarts/uni-echarts.vue
@@ -39,7 +39,7 @@
       type="2d"
       :disable-scroll="props.disableScroll"
       @touchstart="touch.onStart"
-      @touchmove="throttledMove"
+      @touchmove="touch.onMove"
       @touchend="touch.onEnd"></canvas>
 
     <canvas
@@ -49,17 +49,17 @@
       :canvas-id="canvasId"
       :disable-scroll="props.disableScroll"
       @touchstart="touch.onStart"
-      @touchmove="throttledMove"
+      @touchmove="touch.onMove"
       @touchend="touch.onEnd"></canvas>
 
     <view
       v-if="isPc"
       class="uni-echarts__mask"
       @mousedown="touch.onStart"
-      @mousemove="throttledMove"
+      @mousemove="touch.onMove"
       @mouseup="touch.onEnd"
       @touchstart="touch.onStart"
-      @touchmove="throttledMove"
+      @touchmove="touch.onMove"
       @touchend="touch.onEnd"></view>
 
     <slot></slot>
@@ -196,30 +196,6 @@ const touch = useEchartsTouch({
   canvasRect,
   getTouch
 });
-
-const requestFrame = computed(() => chart.value?.getDom()?.canvasNode?.requestAnimationFrame ?? requestAnimationFrame ?? ((fn) => setTimeout(fn, 16)));
-const cancelFrame = computed(() => chart.value?.getDom()?.canvasNode?.cancelAnimationFrame ?? cancelAnimationFrame ?? clearTimeout);
-
-let ticking = false;
-let lastMoveEvent = null;
-let rafToken = null;
-
-function throttledMove(event) {
-  lastMoveEvent = { ...event };
-  if (ticking) {
-    return;
-  }
-
-  ticking = true;
-  rafToken = requestFrame.value(() => {
-    try {
-      touch.onMove(lastMoveEvent);
-    } finally {
-      ticking = false;
-      lastMoveEvent = null;
-    }
-  });
-}
 
 // #ifdef WEB
 
@@ -403,16 +379,11 @@ async function resize(options = {}) {
 }
 
 function cleanup() {
-  if (rafToken !== null) {
-    cancelFrame.value?.(rafToken);
-    rafToken = null;
-    lastMoveEvent = null;
-    ticking = false;
-  }
-
   if (chart.value == null) {
     return;
   }
+
+  touch.cleanup();
 
   chart.value.dispose();
   chart.value = null;

--- a/packages/shared/src/composables/useEchartsTouch.ts
+++ b/packages/shared/src/composables/useEchartsTouch.ts
@@ -59,7 +59,7 @@ export function useEchartsTouch({
 
   let ticking = false;
   let rafId = 0;
-  let lastMoveEvent: TouchEvent | null = null;
+  let lastMoveEvent: NullableValue<TouchEvent> = null;
 
   function destroyTimer() {
     if (timer === 0) {
@@ -70,7 +70,7 @@ export function useEchartsTouch({
     timer = 0;
   }
 
-  function getCanvas(): UniCanvas | null {
+  function getCanvas(): NullableValue<UniCanvas> {
     if (chart.value == null) {
       return null;
     }

--- a/packages/shared/src/composables/useEchartsTouch.ts
+++ b/packages/shared/src/composables/useEchartsTouch.ts
@@ -45,6 +45,7 @@ export function useEchartsTouch({
   onStart: (event: TouchEvent) => void;
   onMove: (event: TouchEvent) => void;
   onEnd: (event: TouchEvent) => void;
+  cleanup: () => void;
 } {
   const touching = shallowRef(false);
 
@@ -56,6 +57,10 @@ export function useEchartsTouch({
 
   let timer = 0;
 
+  let ticking = false;
+  let rafId = 0;
+  let lastMoveEvent: TouchEvent | null = null;
+
   function destroyTimer() {
     if (timer === 0) {
       return;
@@ -63,6 +68,14 @@ export function useEchartsTouch({
 
     clearTimeout(timer);
     timer = 0;
+  }
+
+  function getCanvas(): UniCanvas | null {
+    if (chart.value == null) {
+      return null;
+    }
+
+    return chart.value.getDom() as unknown as UniCanvas;
   }
 
   function normalizeTouches(touches: TouchList) {
@@ -128,7 +141,7 @@ export function useEchartsTouch({
     next();
   }
 
-  function onMove(event: TouchEvent) {
+  function _onMove(event: TouchEvent) {
     if (isPc && toValue(supportHover) && !touching.value) {
       touching.value = true;
     }
@@ -140,6 +153,33 @@ export function useEchartsTouch({
     const { handler } = chart.value.getZr();
     UniCanvas.dispatch(handler, "mousemove", getTouch(event, normalizeTouches(event.touches)));
     handler.processGesture(transformTouchesEvent(event), "change");
+  }
+
+  function onMove(event: TouchEvent) {
+    const canvas = getCanvas();
+
+    if (canvas == null) {
+      return;
+    }
+
+    lastMoveEvent = event;
+
+    if (ticking) {
+      return;
+    }
+
+    ticking = true;
+
+    rafId = canvas.requestAnimationFrame(() => {
+      try {
+        if (lastMoveEvent != null) {
+          _onMove(lastMoveEvent);
+        }
+      } finally {
+        lastMoveEvent = null;
+        ticking = false;
+      }
+    });
   }
 
   function onEnd(event: TouchEvent) {
@@ -172,9 +212,27 @@ export function useEchartsTouch({
     }
   }
 
+  function cleanup() {
+    destroyTimer();
+
+    if (rafId !== 0) {
+      const canvas = getCanvas();
+
+      if (canvas != null) {
+        canvas.cancelAnimationFrame(rafId);
+      }
+
+      rafId = 0;
+    }
+
+    lastMoveEvent = null;
+    ticking = false;
+  }
+
   return {
     onStart,
     onMove,
-    onEnd
+    onEnd,
+    cleanup
   };
 }

--- a/packages/shared/src/utils/canvas.ts
+++ b/packages/shared/src/utils/canvas.ts
@@ -235,6 +235,30 @@ export class UniCanvas {
     // noop
   }
 
+  requestAnimationFrame(callback: () => void): number {
+    if (this.canvasNode != null) {
+      return this.canvasNode.requestAnimationFrame(callback);
+    }
+
+    if (typeof requestAnimationFrame === "function") {
+      return requestAnimationFrame(callback);
+    }
+
+    return setTimeout(callback, 1000 / 60);
+  }
+
+  cancelAnimationFrame(id: number): void {
+    if (this.canvasNode != null) {
+      return this.canvasNode.cancelAnimationFrame(id);
+    }
+
+    if (typeof cancelAnimationFrame === "function") {
+      return cancelAnimationFrame(id);
+    }
+
+    return clearTimeout(id);
+  }
+
   toTempFilePath(options: Omit<UniApp.CanvasToTempFilePathOptions, "canvasId" | "canvas"> = {}): Promise<UniApp.CanvasToTempFilePathRes> {
     const opts: Partial<
       Pick<

--- a/packages/shared/src/utils/canvas.ts
+++ b/packages/shared/src/utils/canvas.ts
@@ -236,7 +236,7 @@ export class UniCanvas {
   }
 
   requestAnimationFrame(callback: () => void): number {
-    if (this.canvasNode != null) {
+    if (this.canvasNode != null && typeof this.canvasNode.requestAnimationFrame === "function") {
       return this.canvasNode.requestAnimationFrame(callback);
     }
 
@@ -248,15 +248,17 @@ export class UniCanvas {
   }
 
   cancelAnimationFrame(id: number): void {
-    if (this.canvasNode != null) {
-      return this.canvasNode.cancelAnimationFrame(id);
+    if (this.canvasNode != null && typeof this.canvasNode.cancelAnimationFrame === "function") {
+      this.canvasNode.cancelAnimationFrame(id);
+      return;
     }
 
     if (typeof cancelAnimationFrame === "function") {
-      return cancelAnimationFrame(id);
+      cancelAnimationFrame(id);
+      return;
     }
 
-    return clearTimeout(id);
+    clearTimeout(id);
   }
 
   toTempFilePath(options: Omit<UniApp.CanvasToTempFilePathOptions, "canvasId" | "canvas"> = {}): Promise<UniApp.CanvasToTempFilePathRes> {


### PR DESCRIPTION
利用 `requestanimationFrame()` 限制 `touch.onMove()` 调用频率。 尝试过 WXS 方式，效果不明显，可能因为无法减少视图层到逻辑层的通信量

参考文档：
https://developers.weixin.qq.com/miniprogram/dev/framework/view/interactive-animation.html

try to fix #12 
replace #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新特性**
  * 为画布添加动画帧调度能力，提供更稳定的帧回调支持与兼容性。
* **优化**
  * 触摸移动事件使用帧合并节流，滑动更流畅且降低性能开销。
  * 强化触摸与组件的清理流程，避免残留计时器与事件，提升稳定性与内存安全。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->