### PR TITLE
feat!: 新增 Vite 插件自动化处理繁琐任务

### DIFF
--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -63,7 +63,13 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
         { text: "关于 ECharts", link: "/echarts" },
         { text: "依赖注入", link: "/provide" },
         { text: "常见问题", link: "/faq" },
-        { text: "更新日志", link: "/changelog" }
+        { text: "更新日志", link: "/changelog" },
+        {
+          text: "迁移指南",
+          items: [
+            { text: "从 1.x 迁移到 2.x", link: "/migration-v1" }
+          ]
+        }
       ]
     }
   ];

--- a/docs/apis/function.md
+++ b/docs/apis/function.md
@@ -3,12 +3,11 @@
 ## provideEcharts
 
 ```ts
-type MinifyEcharts = Pick<
-  typeof Echarts,
-  "init" | "registerPreprocessor" | "setPlatformAPI" | "use" | "throttle"
->;
+import type * as Echarts from "echarts/core";
 
-declare function provideEcharts(echarts: MinifyEcharts): void;
+export type CoreEcharts = typeof Echarts;
+
+declare function provideEcharts(echarts: CoreEcharts): void;
 ```
 
 ## provideEchartsTheme

--- a/docs/guide/echarts.md
+++ b/docs/guide/echarts.md
@@ -15,3 +15,53 @@
 ```js
 import "echarts";
 ```
+
+## 定制 ECharts
+
+通常情况，使用 [按需导入](#按需导入) 就能有效减小打包体积，但是在某些场景如果需要使用定制的 ECharts，
+在 Uni ECharts 中可以配合 [provideEcharts](../apis/function#provideecharts) 实现。
+
+首先到 ECharts 官网 [在线定制](https://echarts.apache.org/zh/builder.html) 并打包下载 `echarts` 到项目中
+（建议放到主包或分包的 `static` 目录下），然后参考下述方案实现。
+
+### NPM 方式
+
+自 `2.0.0` 开始，npm 方式可以通过修改 Vite 插件配置轻松实现。
+
+```js
+// vite.config.js[ts]
+import { UniEcharts } from "uni-echarts/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  // ...
+  plugins: [
+    UniEcharts({
+      // 传实际的 echarts 路径，例如："@/static/echarts.min.js"
+      provideECharts: "/path/to/echarts.min.js" // [!code ++]
+    })
+  ]
+});
+```
+
+当然，也可以手动调用，示例如下：
+
+```js
+import * as echarts from "echarts/core";// [!code --]
+import { provideEcharts } from "uni-echarts/shared";
+import echarts from "/path/to/echarts.min.js";// [!code ++]
+
+provideEcharts(echarts);
+```
+
+### Uni Modules 方式
+
+使用 uni-modules 方式需要手动调用，示例如下：
+
+```js
+import * as echarts from "echarts/core";// [!code --]
+import { provideEcharts } from "@/uni_modules/xiaohe-echarts";
+import echarts from "/path/to/echarts.min.js";// [!code ++]
+
+provideEcharts(echarts);
+```

--- a/docs/guide/echarts.md
+++ b/docs/guide/echarts.md
@@ -49,7 +49,7 @@ export default defineConfig({
 ```js
 import * as echarts from "echarts/core";// [!code --]
 import { provideEcharts } from "uni-echarts/shared";
-import echarts from "/path/to/echarts.min.js";// [!code ++]
+import * as echarts from "/path/to/echarts.min.js";// [!code ++]
 
 provideEcharts(echarts);
 ```
@@ -61,7 +61,7 @@ provideEcharts(echarts);
 ```js
 import * as echarts from "echarts/core";// [!code --]
 import { provideEcharts } from "@/uni_modules/xiaohe-echarts";
-import echarts from "/path/to/echarts.min.js";// [!code ++]
+import * as echarts from "/path/to/echarts.min.js";// [!code ++]
 
 provideEcharts(echarts);
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -51,8 +51,7 @@ export default defineConfig({
 
 #### Vite 插件（可选）
 
-自 `1.2.0` 开始，Uni ECharts 提供了 Vite 插件用于自动化处理一些繁琐、重复的工作，
-例如自动补充 [provideEcharts(echarts)](../apis/function#provideecharts) 的调用。
+自 `1.2.0` 开始，Uni ECharts 提供了 Vite 插件用于自动化处理一些繁琐、重复的工作，也为将来更多的高级功能提供了可能性。
 
 ```js
 // vite.config.js[ts]

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -49,6 +49,24 @@ export default defineConfig({
 });
 ```
 
+#### Vite 插件（可选）
+
+自 `1.2.0` 开始，Uni ECharts 提供了 Vite 插件用于自动化处理一些繁琐、重复的工作，
+例如自动补充 [provideEcharts(echarts)](../apis/function#provideecharts) 的调用。
+
+```js
+// vite.config.js[ts]
+import { UniEcharts } from "uni-echarts/vite"; // [!code ++]
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  // ...
+  plugins: [
+    UniEcharts() // [!code ++]
+  ]
+});
+```
+
 #### 自动导入（可选）
 
 Uni ECharts 可以配合 [@uni-helper/vite-plugin-uni-components](https://github.com/uni-helper/vite-plugin-uni-components)
@@ -137,6 +155,7 @@ import { ref } from "vue";
 // 小程序端的 npm 插件内部无法正确获取到业务侧的 echarts
 // 所以需要手动将 echarts 提供给插件用于构建图表
 provideEcharts(echarts); // 🚨 注意：npm 方式需要添加这一行代码
+// 🤩 自 1.2.0 开始，通过配置 Vite 插件可以省略上述 provideEcharts 的调用
 
 // 此处仅用于演示通过 provide 修改图表 theme 的方式，不是必需
 provideEchartsTheme("dark");

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -150,13 +150,11 @@ import UniEcharts from "uni-echarts"; // [!code --]
 import { provideEcharts, provideEchartsTheme } from "uni-echarts/shared"; // [!code --]
 import { ref } from "vue";
 
-// 由于尚未明确的原因，目前 npm 插件的编译机制存在问题
-// 小程序端的 npm 插件内部无法正确获取到业务侧的 echarts
-// 所以需要手动将 echarts 提供给插件用于构建图表
-provideEcharts(echarts); // 🚨 注意：npm 方式需要添加这一行代码
+// 🚨 注意：必须调用 provideEcharts 才能正常运行
+provideEcharts(echarts);
 // 🤩 自 2.0.0 开始，通过配置 Vite 插件可以省略上述 provideEcharts 的调用
 
-// 此处仅用于演示通过 provide 修改图表 theme 的方式，不是必需
+// 此处仅用于演示通过 provide 修改图表 theme 的方式，不是必须的
 provideEchartsTheme("dark");
 
 echarts.use([
@@ -222,6 +220,100 @@ const option = ref({
 </style>
 ```
 
+::: details Options API 示例
+
+```vue
+<template>
+  <uni-echarts custom-class="chart" :option="option"></uni-echarts>
+</template>
+
+<script>
+import { PieChart } from "echarts/charts";
+import { DatasetComponent, LegendComponent, TooltipComponent } from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import UniEcharts from "uni-echarts";
+import { ECHARTS_KEY, THEME_KEY } from "uni-echarts/shared";
+import { defineComponent } from "vue";
+
+echarts.use([
+  LegendComponent,
+  TooltipComponent,
+  DatasetComponent,
+  PieChart,
+  CanvasRenderer
+]);
+
+export default defineComponent({
+  components: {
+    UniEcharts
+  },
+  provide: {
+    [ECHARTS_KEY]: echarts,
+    [THEME_KEY]: "dark"
+  },
+  data() {
+    return {
+      option: {
+        legend: {
+          top: 10,
+          left: "center"
+        },
+        tooltip: {
+          trigger: "item",
+          textStyle: {
+            // #ifdef MP-WEIXIN
+            // 临时解决微信小程序 tooltip 文字阴影问题
+            textShadowBlur: 1
+            // #endif
+          }
+        },
+        series: [
+          {
+            type: "pie",
+            radius: ["30%", "52%"],
+            label: {
+              show: false,
+              position: "center"
+            },
+            itemStyle: {
+              borderWidth: 2,
+              borderColor: "#ffffff",
+              borderRadius: 10
+            },
+            emphasis: {
+              label: {
+                show: true,
+                fontSize: 20
+              }
+            }
+          }
+        ],
+        dataset: {
+          dimensions: ["来源", "数量"],
+          source: [
+            ["Search Engine", 1048],
+            ["Direct", 735],
+            ["Email", 580],
+            ["Union Ads", 484],
+            ["Video Ads", 300]
+          ]
+        }
+      }
+    };
+  }
+});
+</script>
+
+<style scoped>
+.chart {
+  height: 300px;
+}
+</style>
+```
+
+:::
+
 ## Uni Modules 方式
 
 ### 安装
@@ -271,16 +363,19 @@ Uni ECharts 支持 [easycom](https://uniapp.dcloud.net.cn/component/#easycom) �
 <script setup>
 import { PieChart } from "echarts/charts";
 import { DatasetComponent, LegendComponent, TooltipComponent } from "echarts/components";
-import { use } from "echarts/core";
+import * as echarts from "echarts/core";
 import { CanvasRenderer } from "echarts/renderers";
 import { ref } from "vue";
 // 🚨 注意导入路径与 npm 方式的区别
-import { provideEchartsTheme } from "@/uni_modules/xiaohe-echarts";
+import { provideEcharts, provideEchartsTheme } from "@/uni_modules/xiaohe-echarts";
 
-// 此处仅用于演示通过 provide 修改图表 theme 的方式，不是必需
+// 🚨 注意：自 2.0.0 开始，uni-modules 方式也必须调用 provideEcharts 才能正常运行
+provideEcharts(echarts);
+
+// 此处仅用于演示通过 provide 修改图表 theme 的方式，不是必须的
 provideEchartsTheme("dark");
 
-use([
+echarts.use([
   LegendComponent,
   TooltipComponent,
   DatasetComponent,
@@ -342,3 +437,93 @@ const option = ref({
 }
 </style>
 ```
+
+::: details Options API 示例
+
+```vue
+<template>
+  <uni-echarts custom-class="chart" :option="option"></uni-echarts>
+</template>
+
+<script>
+import { PieChart } from "echarts/charts";
+import { DatasetComponent, LegendComponent, TooltipComponent } from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+import { defineComponent } from "vue";
+import { ECHARTS_KEY, THEME_KEY } from "@/uni_modules/xiaohe-echarts";
+
+echarts.use([
+  LegendComponent,
+  TooltipComponent,
+  DatasetComponent,
+  PieChart,
+  CanvasRenderer
+]);
+
+export default defineComponent({
+  provide: {
+    [ECHARTS_KEY]: echarts,
+    [THEME_KEY]: "dark"
+  },
+  data() {
+    return {
+      option: {
+        legend: {
+          top: 10,
+          left: "center"
+        },
+        tooltip: {
+          trigger: "item",
+          textStyle: {
+            // #ifdef MP-WEIXIN
+            // 临时解决微信小程序 tooltip 文字阴影问题
+            textShadowBlur: 1
+            // #endif
+          }
+        },
+        series: [
+          {
+            type: "pie",
+            radius: ["30%", "52%"],
+            label: {
+              show: false,
+              position: "center"
+            },
+            itemStyle: {
+              borderWidth: 2,
+              borderColor: "#ffffff",
+              borderRadius: 10
+            },
+            emphasis: {
+              label: {
+                show: true,
+                fontSize: 20
+              }
+            }
+          }
+        ],
+        dataset: {
+          dimensions: ["来源", "数量"],
+          source: [
+            ["Search Engine", 1048],
+            ["Direct", 735],
+            ["Email", 580],
+            ["Union Ads", 484],
+            ["Video Ads", 300]
+          ]
+        }
+      }
+    };
+  }
+});
+</script>
+
+<style scoped>
+.chart {
+  height: 300px;
+}
+</style>
+```
+
+:::

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ Uni ECharts 提供了 [npm](#npm-方式) 和 [uni-modules](#uni-modules-方式) 
 
 :::
 
-## NPM 方式
+## NPM 方式 <Badge text="推荐" />
 
 ### 安装
 
@@ -49,9 +49,9 @@ export default defineConfig({
 });
 ```
 
-#### Vite 插件（可选）
+#### Vite 插件
 
-自 `1.2.0` 开始，Uni ECharts 提供了 Vite 插件用于自动化处理一些繁琐、重复的工作，也为将来更多的高级功能提供了可能性。
+自 `2.0.0` 开始，Uni ECharts 提供了 Vite 插件用于自动化处理一些繁琐、重复的工作，也为将来更多的高级功能提供了可能性。
 
 ```js
 // vite.config.js[ts]
@@ -154,7 +154,7 @@ import { ref } from "vue";
 // 小程序端的 npm 插件内部无法正确获取到业务侧的 echarts
 // 所以需要手动将 echarts 提供给插件用于构建图表
 provideEcharts(echarts); // 🚨 注意：npm 方式需要添加这一行代码
-// 🤩 自 1.2.0 开始，通过配置 Vite 插件可以省略上述 provideEcharts 的调用
+// 🤩 自 2.0.0 开始，通过配置 Vite 插件可以省略上述 provideEcharts 的调用
 
 // 此处仅用于演示通过 provide 修改图表 theme 的方式，不是必需
 provideEchartsTheme("dark");

--- a/docs/guide/migration-v1.md
+++ b/docs/guide/migration-v1.md
@@ -1,0 +1,44 @@
+# 从 1.x 迁移到 2.x
+
+本章介绍了 Uni ECharts 从 1.x 迁移到 2.x 有哪些新增特性以及破坏性变更。
+
+## NPM 方式
+
+### 新增特性
+
+- Vite 插件
+
+  自 `2.0.0` 开始，Uni ECharts 在 npm 版本中提供了一个 Vite 插件用于自动化处理一些繁琐、重复的工作。
+  由于插件可以自动完成 `provideEcharts` 的调用，所以组件内部将不再填充 `echarts/core` 作为默认的 `echarts` 插件，
+  同时也间接支持了定制 `echarts` 的使用（还解决了小程序端 `echarts/core` 生成重复问题，进一步节省了小程序宝贵的空间）。
+
+## Uni Modules 方式
+
+### 破坏性变更
+
+- 需要手动调用 provideEcharts 方法
+
+  自 `2.0.0` 开始，为了支持定制 `echarts` 的使用，组件将不再自动填充 `echarts/core` 作为默认的 `echarts` 插件，
+  所以必须要手动调用 `provideEcharts`，示例如下：
+
+  ```js
+  import * as echarts from "echarts/core";
+  import { provideEcharts } from "@/uni_modules/xiaohe-echarts";
+
+  provideEcharts(echarts);
+  ```
+
+  ::: details Options API 示例
+
+  ```js
+  import * as echarts from "echarts/core";
+  import { defineComponent } from "vue";
+  import { ECHARTS_KEY } from "@/uni_modules/xiaohe-echarts";
+
+  export default defineComponent({
+    provide: {
+      [ECHARTS_KEY]: echarts
+    }
+  });
+  ```
+  :::

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
     "**/*.md",
     "packages/core/src/shared-core.*",
     "packages/core/dist-resolver",
+    "packages/core/dist-vite",
     "playground/src/uni_modules"
   ]
 }, {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "1.1.2",
   "private": true,
-  "packageManager": "pnpm@10.15.1",
+  "packageManager": "pnpm@10.16.1",
   "description": "🪀 适用于 uni-app 的 Apache ECharts 组件（仅支持Vue 3）",
   "scripts": {
     "prepare": "simple-git-hooks",
@@ -18,7 +18,7 @@
     "docs:dev": "nr -C docs dev",
     "docs:build": "nr -C docs build && nr build:play && esno scripts/compose-docs.ts",
     "release": "bumpp -r",
-    "clean": "rimraf **/dist **/dist-resolver **/uni_modules --glob",
+    "clean": "rimraf **/dist **/dist-resolver **/dist-vite **/uni_modules --glob",
     "lint": "eslint --cache",
     "lint:fix": "nr lint --fix",
     "lint:type": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@dcloudio/types": "catalog:dcloudio",
     "@mini-types/alipay": "catalog:dev",
     "@types/fs-extra": "catalog:types",
+    "@types/node": "catalog:types",
     "@uni-helper/uni-app-types": "catalog:dev",
     "@xiaohe01/eslint-config": "catalog:lint",
     "@xiaohe01/stylelint-config": "catalog:lint",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "1.1.2",
   "private": true,
-  "packageManager": "pnpm@10.16.1",
+  "packageManager": "pnpm@10.17.0",
   "description": "🪀 适用于 uni-app 的 Apache ECharts 组件（仅支持Vue 3）",
   "scripts": {
     "prepare": "simple-git-hooks",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.1.2",
   "private": true,
   "packageManager": "pnpm@10.17.0",
-  "description": "🪀 适用于 uni-app 的 Apache ECharts 组件（仅支持Vue 3）",
   "scripts": {
     "prepare": "simple-git-hooks",
     "postinstall": "nr build",

--- a/packages/c2e/build.config.ts
+++ b/packages/c2e/build.config.ts
@@ -2,9 +2,11 @@ import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig({
   entries: [
-    "src/index.ts"
+    "src/index.ts",
+    "src/cli.ts"
   ],
   clean: true,
+  declaration: true,
   externals: [
     "@clack/prompts",
     "@rollup/plugin-commonjs",

--- a/packages/c2e/build.config.ts
+++ b/packages/c2e/build.config.ts
@@ -1,0 +1,20 @@
+import { defineBuildConfig } from "unbuild";
+
+export default defineBuildConfig({
+  entries: [
+    "src/index.ts"
+  ],
+  clean: true,
+  externals: [
+    "@clack/prompts",
+    "@rollup/plugin-commonjs",
+    "@rollup/plugin-node-resolve",
+    "@rollup/plugin-terser",
+    "chalk",
+    "minimist",
+    "rollup"
+  ],
+  rollup: {
+    emitCJS: true
+  }
+});

--- a/packages/c2e/package.json
+++ b/packages/c2e/package.json
@@ -12,11 +12,22 @@
   },
   "bugs": "https://github.com/xiaohe0601/uni-echarts/issues",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./*": "./*"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "bin": {
-    "uni-echarts-c2e": "./dist/index.cjs"
+    "uni-echarts-c2e": "./dist/cli.cjs"
   },
   "files": [
-    "dist/index.cjs"
+    "dist"
   ],
   "scripts": {
     "build": "unbuild"

--- a/packages/c2e/package.json
+++ b/packages/c2e/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@uni-echarts/c2e",
+  "type": "module",
+  "version": "1.1.2",
+  "description": "🪀 Transform CJS to ESM for Uni ECharts.",
+  "author": "xiaohe0601 <xiaohe0601@outlook.com>",
+  "license": "MIT",
+  "homepage": "https://uni-echarts.xiaohe.ink",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/xiaohe0601/uni-echarts.git"
+  },
+  "bugs": "https://github.com/xiaohe0601/uni-echarts/issues",
+  "sideEffects": false,
+  "bin": {
+    "uni-echarts-c2e": "./dist/index.cjs"
+  },
+  "files": [
+    "dist/index.cjs"
+  ],
+  "scripts": {
+    "build": "unbuild"
+  },
+  "dependencies": {
+    "@rollup/plugin-terser": "catalog:build"
+  },
+  "devDependencies": {
+    "@clack/prompts": "catalog:node",
+    "@rollup/plugin-commonjs": "catalog:build",
+    "@rollup/plugin-node-resolve": "catalog:build",
+    "@types/minimist": "catalog:types",
+    "chalk": "catalog:node",
+    "minimist": "catalog:dev"
+  }
+}

--- a/packages/c2e/src/cli.ts
+++ b/packages/c2e/src/cli.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import * as process from "node:process";
+import { cancel, confirm, intro, isCancel, log, outro, spinner, text } from "@clack/prompts";
+import chalk from "chalk";
+import minimist from "minimist";
+import { c2e } from "./index";
+
+async function prompt<T extends (...args: any[]) => Promise<any>>(
+  func: T,
+  options: Parameters<T>[0]
+): Promise<Awaited<ReturnType<T>>> {
+  const value = await func(options);
+
+  if (isCancel(value)) {
+    cancel("Operation cancelled");
+    process.exit(0);
+  }
+
+  return value;
+}
+
+async function main() {
+  const argv = minimist(process.argv.slice(2), {
+    alias: {
+      force: ["f"],
+      help: ["h"]
+    }
+  });
+
+  intro("Uni ECharts Transform CLI");
+
+  log.info(`Transform input ${chalk.cyan("echarts.min.js")} to ESM`);
+
+  if (argv.help) {
+    help();
+    process.exit(0);
+  }
+
+  const input = await prompt(text, {
+    message: "Input file",
+    placeholder: "./echarts.min.js",
+    initialValue: argv._[0],
+    validate(value) {
+      if (value.length === 0) {
+        return new Error("Input file is required.");
+      }
+      if (!fs.existsSync(value)) {
+        return new Error("Input file does not exist.");
+      }
+      if (!fs.statSync(value).isFile()) {
+        return new Error("Input path is not a file.");
+      }
+    }
+  }) as string;
+
+  const output = await prompt(text, {
+    message: "Output file",
+    placeholder: "./echarts.esm.js",
+    initialValue: argv._[1],
+    validate(value) {
+      if (value.length === 0) {
+        return new Error("Output file is required.");
+      }
+    }
+  }) as string;
+
+  if (!argv.force && fs.existsSync(output)) {
+    const overwrite = await prompt(confirm, {
+      message: `${chalk.cyan(output)} already exists. Overwrite?`
+    });
+
+    if (!overwrite) {
+      cancel("Operation cancelled. File not overwritten.");
+      process.exit(0);
+    }
+  }
+
+  const s = spinner();
+
+  s.start("Transforming...");
+
+  try {
+    await c2e({
+      write: true,
+      input,
+      output
+    });
+
+    s.stop("Transform completed!");
+
+    outro(chalk.green(`Output: ${chalk.cyan(fs.realpathSync(output))}`));
+  } catch (error: any) {
+    s.stop();
+
+    cancel(`Transform failed: ${chalk.red(error.message || error)}`);
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+function help() {
+  log.info(`
+Usage:
+  $ uni-echarts-c2e [input] [output] [options]
+
+Arguments:
+  input     Input file path (e.g., ${chalk.cyan("./echarts.min.js")})
+  output    Output file path (e.g., ${chalk.cyan("./echarts.esm.js")})
+
+Options:
+  -f, --force   Overwrite output if it exists
+  -h, --help    Display this message
+
+Examples:
+  $ uni-echarts-c2e ./echarts.min.js ./echarts.esm.js
+  $ uni-echarts-c2e ./echarts.min.js ./echarts.esm.js -f
+  $ uni-echarts-c2e --help
+`.trim());
+}
+
+void main();

--- a/packages/c2e/src/index.ts
+++ b/packages/c2e/src/index.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import * as process from "node:process";
+import { cancel, confirm, intro, isCancel, log, outro, spinner, text } from "@clack/prompts";
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
+import terser from "@rollup/plugin-terser";
+import chalk from "chalk";
+import minimist from "minimist";
+import type { RollupBuild } from "rollup";
+import { rollup } from "rollup";
+
+async function c2e(input: string, output: string) {
+  let bundle: RollupBuild | null = null;
+
+  try {
+    bundle = await rollup({
+      input,
+      plugins: [
+        resolve(),
+        commonjs(),
+        terser()
+        // TODO replace wx to uni
+      ]
+    });
+
+    await bundle.write({
+      file: output,
+      format: "esm"
+    });
+  } finally {
+    if (bundle != null) {
+      await bundle.close();
+    }
+  }
+}
+
+async function prompt<T extends (...args: any[]) => Promise<any>>(
+  func: T,
+  options: Parameters<T>[0]
+): Promise<Awaited<ReturnType<T>>> {
+  const value = await func(options);
+
+  if (isCancel(value)) {
+    cancel("Operation cancelled");
+    process.exit(0);
+  }
+
+  return value;
+}
+
+async function main() {
+  const argv = minimist(process.argv.slice(2), {
+    alias: {
+      force: ["f"],
+      help: ["h"]
+    }
+  });
+
+  intro("Uni ECharts Transform CLI");
+
+  log.info(`Transform input ${chalk.cyan("echarts.min.js")} to ESM`);
+
+  if (argv.help) {
+    help();
+    process.exit(0);
+  }
+
+  const input = await prompt(text, {
+    message: "Input file",
+    placeholder: "./echarts.min.js",
+    initialValue: argv._[0],
+    validate(value) {
+      if (value.length === 0) {
+        return new Error("Input file is required.");
+      }
+      if (!fs.existsSync(value)) {
+        return new Error("Input file does not exist.");
+      }
+      if (!fs.statSync(value).isFile()) {
+        return new Error("Input path is not a file.");
+      }
+    }
+  }) as string;
+
+  const output = await prompt(text, {
+    message: "Output file",
+    placeholder: "./echarts.esm.js",
+    initialValue: argv._[1],
+    validate(value) {
+      if (value.length === 0) {
+        return new Error("Output file is required.");
+      }
+    }
+  }) as string;
+
+  if (!argv.force && fs.existsSync(output)) {
+    const overwrite = await prompt(confirm, {
+      message: `${chalk.cyan(output)} already exists. Overwrite?`
+    });
+
+    if (!overwrite) {
+      cancel("Operation cancelled. File not overwritten.");
+      process.exit(0);
+    }
+  }
+
+  const s = spinner();
+
+  s.start("Transforming...");
+
+  try {
+    await c2e(input, output);
+
+    s.stop("Transform completed!");
+
+    outro(chalk.green(`Output: ${chalk.cyan(fs.realpathSync(output))}`));
+  } catch (error: any) {
+    s.stop();
+
+    cancel(`Transform failed: ${chalk.red(error.message || error)}`);
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+function help() {
+  log.info(`
+Usage:
+  $ c2e [input] [output] [options]
+
+Arguments:
+  input     Input file path (e.g., ${chalk.cyan("./echarts.min.js")})
+  output    Output file path (e.g., ${chalk.cyan("./echarts.esm.js")})
+
+Options:
+  -f, --force   Overwrite output if it exists
+  -h, --help    Display this message
+
+Examples:
+  $ c2e ./echarts.min.js ./echarts.esm.js
+  $ c2e ./echarts.min.js ./echarts.esm.js -f
+  $ c2e --help
+`.trim());
+}
+
+void main();

--- a/packages/c2e/src/index.ts
+++ b/packages/c2e/src/index.ts
@@ -1,149 +1,75 @@
-#!/usr/bin/env node
-
-import fs from "node:fs";
-import * as process from "node:process";
-import { cancel, confirm, intro, isCancel, log, outro, spinner, text } from "@clack/prompts";
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
-import chalk from "chalk";
-import minimist from "minimist";
-import type { RollupBuild } from "rollup";
+import type { RollupBuild, RollupOutput } from "rollup";
 import { rollup } from "rollup";
 
-async function c2e(input: string, output: string) {
+export interface C2eWriteOptions {
+  write: true;
+  input: string;
+  output: string;
+}
+
+export interface C2eGenOptions {
+  write: false;
+  code: string;
+}
+
+export type C2eOptions = C2eWriteOptions | C2eGenOptions;
+
+export function c2e(options: C2eWriteOptions): Promise<undefined>;
+export function c2e(options: C2eGenOptions): Promise<RollupOutput>;
+export async function c2e(options: C2eOptions) {
   let bundle: RollupBuild | null = null;
 
   try {
+    const input = options.write ? options.input : "virtual-input.js";
+
+    const plugins = [
+      resolve(),
+      commonjs(),
+      terser()
+      // TODO replace wx to uni
+    ];
+
+    if (!options.write) {
+      plugins.unshift({
+        name: "virtual-input",
+        resolveId(source) {
+          if (source !== input) {
+            return null;
+          }
+
+          return input;
+        },
+        load(id) {
+          if (id !== input) {
+            return null;
+          }
+
+          return options.code;
+        }
+      });
+    }
+
     bundle = await rollup({
       input,
-      plugins: [
-        resolve(),
-        commonjs(),
-        terser()
-        // TODO replace wx to uni
-      ]
+      plugins
     });
 
-    await bundle.write({
-      file: output,
-      format: "esm"
-    });
+    if (options.write) {
+      await bundle.write({
+        file: options.output,
+        format: "esm"
+      });
+    } else {
+      return bundle.generate({
+        format: "esm"
+      });
+    }
   } finally {
     if (bundle != null) {
       await bundle.close();
     }
   }
 }
-
-async function prompt<T extends (...args: any[]) => Promise<any>>(
-  func: T,
-  options: Parameters<T>[0]
-): Promise<Awaited<ReturnType<T>>> {
-  const value = await func(options);
-
-  if (isCancel(value)) {
-    cancel("Operation cancelled");
-    process.exit(0);
-  }
-
-  return value;
-}
-
-async function main() {
-  const argv = minimist(process.argv.slice(2), {
-    alias: {
-      force: ["f"],
-      help: ["h"]
-    }
-  });
-
-  intro("Uni ECharts Transform CLI");
-
-  log.info(`Transform input ${chalk.cyan("echarts.min.js")} to ESM`);
-
-  if (argv.help) {
-    help();
-    process.exit(0);
-  }
-
-  const input = await prompt(text, {
-    message: "Input file",
-    placeholder: "./echarts.min.js",
-    initialValue: argv._[0],
-    validate(value) {
-      if (value.length === 0) {
-        return new Error("Input file is required.");
-      }
-      if (!fs.existsSync(value)) {
-        return new Error("Input file does not exist.");
-      }
-      if (!fs.statSync(value).isFile()) {
-        return new Error("Input path is not a file.");
-      }
-    }
-  }) as string;
-
-  const output = await prompt(text, {
-    message: "Output file",
-    placeholder: "./echarts.esm.js",
-    initialValue: argv._[1],
-    validate(value) {
-      if (value.length === 0) {
-        return new Error("Output file is required.");
-      }
-    }
-  }) as string;
-
-  if (!argv.force && fs.existsSync(output)) {
-    const overwrite = await prompt(confirm, {
-      message: `${chalk.cyan(output)} already exists. Overwrite?`
-    });
-
-    if (!overwrite) {
-      cancel("Operation cancelled. File not overwritten.");
-      process.exit(0);
-    }
-  }
-
-  const s = spinner();
-
-  s.start("Transforming...");
-
-  try {
-    await c2e(input, output);
-
-    s.stop("Transform completed!");
-
-    outro(chalk.green(`Output: ${chalk.cyan(fs.realpathSync(output))}`));
-  } catch (error: any) {
-    s.stop();
-
-    cancel(`Transform failed: ${chalk.red(error.message || error)}`);
-    console.error(error);
-
-    process.exit(1);
-  }
-}
-
-function help() {
-  log.info(`
-Usage:
-  $ c2e [input] [output] [options]
-
-Arguments:
-  input     Input file path (e.g., ${chalk.cyan("./echarts.min.js")})
-  output    Output file path (e.g., ${chalk.cyan("./echarts.esm.js")})
-
-Options:
-  -f, --force   Overwrite output if it exists
-  -h, --help    Display this message
-
-Examples:
-  $ c2e ./echarts.min.js ./echarts.esm.js
-  $ c2e ./echarts.min.js ./echarts.esm.js -f
-  $ c2e --help
-`.trim());
-}
-
-void main();

--- a/packages/c2e/tsconfig.json
+++ b/packages/c2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@xiaohe01/tsconfig/tsconfig.basic.json",
+  "compilerOptions": {
+    "lib": [
+      "ES2020"
+    ],
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "build.config.ts"
+  ]
+}

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -6,3 +6,4 @@ shared-core.d.ts
 
 # 制品文件
 dist-resolver
+dist-vite

--- a/packages/core/build.config.ts
+++ b/packages/core/build.config.ts
@@ -40,6 +40,8 @@ export default defineBuildConfig([
     clean: false,
     declaration: true,
     externals: [
+      "@oxc-project/types",
+      "oxc-parser",
       "vite",
       "vue"
     ],

--- a/packages/core/build.config.ts
+++ b/packages/core/build.config.ts
@@ -30,5 +30,22 @@ export default defineBuildConfig([
     rollup: {
       emitCJS: true
     }
+  },
+  {
+    name: "uni-echarts/vite",
+    entries: [
+      "vite/index.ts"
+    ],
+    outDir: "dist-vite",
+    clean: false,
+    declaration: true,
+    externals: [
+      "@vue/compiler-sfc",
+      "vite"
+    ],
+    failOnWarn: false,
+    rollup: {
+      emitCJS: true
+    }
   }
 ]);

--- a/packages/core/build.config.ts
+++ b/packages/core/build.config.ts
@@ -40,8 +40,8 @@ export default defineBuildConfig([
     clean: false,
     declaration: true,
     externals: [
-      "@vue/compiler-sfc",
-      "vite"
+      "vite",
+      "vue"
     ],
     failOnWarn: false,
     rollup: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,6 @@
     "@vue/runtime-core": "catalog:frontend",
     "echarts": "catalog:frontend",
     "oxc-parser": "catalog:dev",
-    "oxc-walker": "catalog:dev",
     "vue": "catalog:frontend"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,8 @@
     "@uni-helper/vite-plugin-uni-components": "catalog:build",
     "@vue/runtime-core": "catalog:frontend",
     "echarts": "catalog:frontend",
+    "oxc-parser": "catalog:dev",
+    "oxc-walker": "catalog:dev",
     "vue": "catalog:frontend"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,17 +33,23 @@
       "import": "./dist-resolver/index.mjs",
       "require": "./dist-resolver/index.cjs"
     },
+    "./vite": {
+      "types": "./dist-vite/index.d.ts",
+      "import": "./dist-vite/index.mjs",
+      "require": "./dist-vite/index.cjs"
+    },
     "./global": "./src/global.d.ts",
     "./*": "./src/*"
   },
   "files": [
     "dist",
     "dist-resolver",
+    "dist-vite",
     "src"
   ],
   "scripts": {
     "build": "nr clean:dist && unbuild && esno scripts/post-build.ts",
-    "clean:dist": "rimraf ./dist ./dist-resolver"
+    "clean:dist": "rimraf ./dist ./dist-resolver ./dist-vite"
   },
   "peerDependencies": {
     "echarts": ">=5.3.0",

--- a/packages/core/scripts/post-build.ts
+++ b/packages/core/scripts/post-build.ts
@@ -20,6 +20,9 @@ async function main() {
     await copy(r("dist-resolver", "resolver"), r("dist-resolver"));
     await remove(r("dist-resolver", "resolver"));
 
+    await copy(r("dist-vite", "vite"), r("dist-vite"));
+    await remove(r("dist-vite", "vite"));
+
     consola.success(chalk.green("Simplify succeeded for dist"));
   } catch (error) {
     consola.error("Simplify failed for `dist`", error);

--- a/packages/core/tsconfig.node.json
+++ b/packages/core/tsconfig.node.json
@@ -10,6 +10,7 @@
   },
   "include": [
     "resolver/**/*",
+    "vite/**/*",
     "scripts/**/*",
     "build.config.ts"
   ]

--- a/packages/core/vite/helpers.ts
+++ b/packages/core/vite/helpers.ts
@@ -7,6 +7,6 @@ export async function parseVueSFC(code: string): Promise<SFCDescriptor> {
 
     // eslint-disable-next-line unused-imports/no-unused-vars
   } catch (error) {
-    throw new Error("[uni-echarts] Vue's version must be 3.2.13 or higher.");
+    throw new Error("Vue's version must be 3.2.13 or higher.");
   }
 }

--- a/packages/core/vite/helpers.ts
+++ b/packages/core/vite/helpers.ts
@@ -1,5 +1,5 @@
-import type { SFCDescriptor } from "@vue/compiler-sfc";
-import { parse as VueParse } from "@vue/compiler-sfc";
+import type { SFCDescriptor } from "vue/compiler-sfc";
+import { parse as VueParse } from "vue/compiler-sfc";
 
 export async function parseVueSFC(code: string): Promise<SFCDescriptor> {
   try {

--- a/packages/core/vite/helpers.ts
+++ b/packages/core/vite/helpers.ts
@@ -1,0 +1,13 @@
+import type { SFCDescriptor } from "@vue/compiler-sfc";
+import { parse as VueParse } from "@vue/compiler-sfc";
+
+export async function parseVueSFC(code: string): Promise<SFCDescriptor> {
+  try {
+    return VueParse(code, { pad: "space" }).descriptor
+      || (VueParse as any)({ source: code });
+
+    // eslint-disable-next-line unused-imports/no-unused-vars
+  } catch (error) {
+    throw new Error("[uni-echarts] Vue's version must be 3.2.13 or higher.");
+  }
+}

--- a/packages/core/vite/helpers.ts
+++ b/packages/core/vite/helpers.ts
@@ -3,8 +3,7 @@ import { parse as VueParse } from "vue/compiler-sfc";
 
 export async function parseVueSFC(code: string): Promise<SFCDescriptor> {
   try {
-    return VueParse(code, { pad: "space" }).descriptor
-      || (VueParse as any)({ source: code });
+    return VueParse(code, { pad: "space" }).descriptor;
 
     // eslint-disable-next-line unused-imports/no-unused-vars
   } catch (error) {

--- a/packages/core/vite/index.ts
+++ b/packages/core/vite/index.ts
@@ -1,0 +1,43 @@
+import type { FilterPattern, Plugin } from "vite";
+import { createFilter } from "vite";
+import { transform } from "./transform";
+
+export interface Options {
+  provideECharts?: boolean;
+  include?: FilterPattern;
+  exclude?: FilterPattern;
+}
+
+export function UniEcharts(options: Options = {}): Plugin {
+  const {
+    provideECharts = true,
+    include = "./src/**/*.vue"
+  } = options;
+
+  const filter = createFilter(include, options.exclude);
+
+  return {
+    name: "uni-echarts",
+    enforce: "pre",
+    async transform(code, id) {
+      if (!filter(id)) {
+        return null;
+      }
+
+      const ms = await transform(code, {
+        provideECharts
+      });
+
+      if (!ms.hasChanged()) {
+        return null;
+      }
+
+      return {
+        code: ms.toString(),
+        map: ms.generateMap({
+          hires: true
+        })
+      };
+    }
+  };
+}

--- a/packages/core/vite/index.ts
+++ b/packages/core/vite/index.ts
@@ -1,16 +1,15 @@
 import type { FilterPattern, Plugin } from "vite";
 import { createFilter } from "vite";
+import type { TransformOptions } from "./transform";
 import { transform } from "./transform";
 
-export interface Options {
-  provideECharts?: boolean;
+export interface Options extends TransformOptions {
   include?: FilterPattern;
   exclude?: FilterPattern;
 }
 
 export function UniEcharts(options: Options = {}): Plugin {
   const {
-    provideECharts = true,
     include = "./src/**/*.vue"
   } = options;
 
@@ -21,15 +20,13 @@ export function UniEcharts(options: Options = {}): Plugin {
     enforce: "pre",
     async transform(code, id) {
       if (!filter(id)) {
-        return null;
+        return;
       }
 
-      const ms = await transform(code, {
-        provideECharts
-      });
+      const ms = await transform(code, options);
 
-      if (!ms.hasChanged()) {
-        return null;
+      if (ms == null || !ms.hasChanged()) {
+        return;
       }
 
       return {

--- a/packages/core/vite/index.ts
+++ b/packages/core/vite/index.ts
@@ -9,11 +9,13 @@ export interface Options extends TransformOptions {
 }
 
 export function UniEcharts(options: Options = {}): Plugin {
-  const {
-    include = "./src/**/*.vue"
-  } = options;
+  const opts = {
+    provideECharts: true,
+    include: "./src/**/*.vue",
+    ...options
+  };
 
-  const filter = createFilter(include, options.exclude);
+  const filter = createFilter(opts.include, opts.exclude);
 
   return {
     name: "uni-echarts",
@@ -23,7 +25,7 @@ export function UniEcharts(options: Options = {}): Plugin {
         return;
       }
 
-      const ms = await transform(code, options);
+      const ms = await transform(code, opts);
 
       if (ms == null || !ms.hasChanged()) {
         return;

--- a/packages/core/vite/transform.ts
+++ b/packages/core/vite/transform.ts
@@ -1,0 +1,97 @@
+import { MagicString } from "@vue/compiler-sfc";
+import { parseVueSFC } from "./helpers";
+
+export interface TransformOptions {
+  provideECharts: boolean;
+}
+
+export async function transform(code: string, options: TransformOptions) {
+  const ms = new MagicString(code);
+
+  if (options.provideECharts) {
+    await injectEChartsProvide(code, ms);
+  }
+
+  return ms;
+}
+
+async function injectEChartsProvide(code: string, ms: MagicString) {
+  const sfc = await parseVueSFC(code);
+
+  if (sfc.template == null) {
+    return;
+  }
+
+  const templateContent = sfc.template.content;
+
+  if (!/<(?:UniEcharts|uni-echarts)/.test(templateContent)) {
+    return;
+  }
+
+  if (sfc.scriptSetup != null) {
+    const { content, loc } = sfc.scriptSetup;
+
+    const hasImportEcharts = /import\s+\*\s+as\s+echarts\s+from\s+["']echarts(?:\/core)?["']/.test(content);
+    const hasImportProvide = /import\s*\{[^}]*\bprovideEcharts\b[^}]*\}\s*from\s*["']uni-echarts\/shared["']/.test(content);
+    const hasProvideCall = /provideEcharts\s*\(\s*echarts\s*\)/.test(content);
+
+    const prependImports: string[] = [];
+
+    if (!hasImportEcharts) {
+      prependImports.push(`import * as echarts from "echarts/core";`);
+    }
+    if (!hasImportProvide) {
+      prependImports.push(`import { provideEcharts } from "uni-echarts/shared";`);
+    }
+
+    if (prependImports.length > 0) {
+      ms.appendLeft(loc.start.offset, `\n${prependImports.join("\n")}`);
+    }
+
+    if (!hasProvideCall) {
+      ms.appendLeft(loc.end.offset, `provideEcharts(echarts);\n`);
+    }
+  } else if (sfc.script != null) {
+    const { content, loc } = sfc.script;
+
+    const hasImportEcharts = /import\s+\*\s+as\s+echarts\s+from\s+["']echarts(?:\/core)?["']/.test(content);
+    const hasImportProvideKey = /import\s*\{[^}]*\bECHARTS_KEY\b[^}]*\}\s*from\s*["']uni-echarts\/shared["']/.test(content);
+
+    const prependImports: string[] = [];
+    if (!hasImportEcharts) {
+      prependImports.push(`import * as echarts from "echarts/core";`);
+    }
+    if (!hasImportProvideKey) {
+      prependImports.push(`import { ECHARTS_KEY } from "uni-echarts/shared";`);
+    }
+
+    if (prependImports.length > 0) {
+      ms.appendLeft(loc.start.offset, `\n${prependImports.join("\n")}`);
+    }
+
+    const exportDefaultRegex = /export\s+default\s*(?:defineComponent\s*)?\(\s*(\{[\s\S]*?\})\s*\)/;
+    const exportDefaultMatch = exportDefaultRegex.exec(content);
+
+    if (exportDefaultMatch != null) {
+      const defaultContent = exportDefaultMatch[1];
+
+      const provideMatch = /(?:^|,)\s*provide\s*:\s*\{([\s\S]*?)\}/m.exec(defaultContent);
+
+      const hasEchartsProvide = provideMatch != null
+        ? /\[?\s*ECHARTS_KEY\s*(?:\]\s*)?:\s*echarts/.test(provideMatch[1])
+        : false;
+
+      if (!hasEchartsProvide) {
+        if (provideMatch != null) {
+          const insertPos = loc.start.offset + exportDefaultMatch.index + provideMatch.index + provideMatch[0].length;
+
+          ms.appendLeft(insertPos, `\n    [ECHARTS_KEY]: echarts,`);
+        } else {
+          const insertPos = loc.start.offset + exportDefaultMatch.index + exportDefaultMatch[0].length;
+
+          ms.appendLeft(insertPos, `\n  provide: { [ECHARTS_KEY]: echarts },`);
+        }
+      }
+    }
+  }
+}

--- a/packages/core/vite/transform.ts
+++ b/packages/core/vite/transform.ts
@@ -1,4 +1,4 @@
-import { MagicString } from "@vue/compiler-sfc";
+import { MagicString } from "vue/compiler-sfc";
 import { parseVueSFC } from "./helpers";
 
 export interface TransformOptions {

--- a/packages/core/vite/transform.ts
+++ b/packages/core/vite/transform.ts
@@ -173,19 +173,17 @@ function findEChartsProvideImports(imports: StaticImport[], options: {
   let hasImportEcharts = false;
   let hasImportProvide = false;
 
-  // eslint-disable-next-line no-labels
-  outer: for (const item of imports) {
+  for (const item of imports) {
     for (const it of item.entries) {
       if (!hasImportEcharts && it.localName.value === "echarts") {
         hasImportEcharts = true;
       } else if (!hasImportProvide && it.localName.value === options.provide) {
         hasImportProvide = true;
       }
+    }
 
-      if (hasImportEcharts && hasImportProvide) {
-        // eslint-disable-next-line no-labels
-        break outer;
-      }
+    if (hasImportEcharts && hasImportProvide) {
+      break;
     }
   }
 

--- a/packages/core/vite/transform.ts
+++ b/packages/core/vite/transform.ts
@@ -173,23 +173,19 @@ function findEChartsProvideImports(imports: StaticImport[], options: {
   let hasImportEcharts = false;
   let hasImportProvide = false;
 
-  for (const item of imports) {
-    if (item.moduleRequest.value === options.echarts) {
-      if (hasImportEcharts) {
-        continue;
+  // eslint-disable-next-line no-labels
+  outer: for (const item of imports) {
+    for (const it of item.entries) {
+      if (!hasImportEcharts && it.localName.value === "echarts") {
+        hasImportEcharts = true;
+      } else if (!hasImportProvide && it.localName.value === options.provide) {
+        hasImportProvide = true;
       }
 
-      hasImportEcharts = item.entries.some((it) => it.localName.value === "echarts");
-    } else if (item.moduleRequest.value === "uni-echarts/shared") {
-      if (hasImportProvide) {
-        continue;
+      if (hasImportEcharts && hasImportProvide) {
+        // eslint-disable-next-line no-labels
+        break outer;
       }
-
-      hasImportProvide = item.entries.some((it) => it.localName.value === options.provide);
-    }
-
-    if (hasImportEcharts && hasImportProvide) {
-      break;
     }
   }
 

--- a/packages/core/vite/transform.ts
+++ b/packages/core/vite/transform.ts
@@ -2,20 +2,36 @@ import { MagicString } from "vue/compiler-sfc";
 import { parseVueSFC } from "./helpers";
 
 export interface TransformOptions {
-  provideECharts: boolean;
+  provideECharts?: boolean | string;
 }
 
 export async function transform(code: string, options: TransformOptions) {
+  const {
+    provideECharts = true
+  } = options;
+
+  if (!provideECharts) {
+    return null;
+  }
+
   const ms = new MagicString(code);
 
-  if (options.provideECharts) {
-    await injectEChartsProvide(code, ms);
+  if (provideECharts) {
+    await injectEChartsProvide(
+      code,
+      ms,
+      provideECharts === true ? "echarts/core" : provideECharts
+    );
   }
 
   return ms;
 }
 
-async function injectEChartsProvide(code: string, ms: MagicString) {
+async function injectEChartsProvide(
+  code: string,
+  ms: MagicString,
+  echarts: string
+) {
   const sfc = await parseVueSFC(code);
 
   if (sfc.template == null) {
@@ -38,7 +54,7 @@ async function injectEChartsProvide(code: string, ms: MagicString) {
     const prependImports: string[] = [];
 
     if (!hasImportEcharts) {
-      prependImports.push(`import * as echarts from "echarts/core";`);
+      prependImports.push(`import * as echarts from "${echarts}";`);
     }
     if (!hasImportProvide) {
       prependImports.push(`import { provideEcharts } from "uni-echarts/shared";`);
@@ -59,7 +75,7 @@ async function injectEChartsProvide(code: string, ms: MagicString) {
 
     const prependImports: string[] = [];
     if (!hasImportEcharts) {
-      prependImports.push(`import * as echarts from "echarts/core";`);
+      prependImports.push(`import * as echarts from "${echarts}";`);
     }
     if (!hasImportProvideKey) {
       prependImports.push(`import { ECHARTS_KEY } from "uni-echarts/shared";`);

--- a/packages/core/vite/transform.ts
+++ b/packages/core/vite/transform.ts
@@ -20,12 +20,8 @@ export interface TransformOptions {
   provideECharts?: boolean | string;
 }
 
-export async function transform(code: string, options: TransformOptions) {
-  const {
-    provideECharts = true
-  } = options;
-
-  if (!provideECharts) {
+export async function transform(code: string, options: Required<TransformOptions>) {
+  if (!options.provideECharts) {
     return null;
   }
 
@@ -45,12 +41,12 @@ export async function transform(code: string, options: TransformOptions) {
 
   const ms = new MagicString(code);
 
-  if (provideECharts) {
+  if (options.provideECharts) {
     await injectEChartsProvide({
       sfc,
       ms,
       asts,
-      echarts: provideECharts === true ? "echarts/core" : provideECharts
+      echarts: options.provideECharts === true ? "echarts/core" : options.provideECharts
     });
   }
 

--- a/packages/shared/build.config.ts
+++ b/packages/shared/build.config.ts
@@ -8,7 +8,7 @@ export default defineBuildConfig({
   clean: true,
   declaration: true,
   externals: [
-    "echarts/core",
+    "echarts",
     "vue"
   ],
   hooks: {

--- a/packages/shared/src/composables/useAutoresize.ts
+++ b/packages/shared/src/composables/useAutoresize.ts
@@ -1,7 +1,7 @@
 import type { ComponentPublicInstance, MaybeRefOrGetter, Ref } from "vue";
 import { watch } from "vue";
 import type { EChartsType, NullableValue } from "../types";
-import type { MinifyEcharts } from "./useEcharts";
+import type { CoreEcharts } from "./useEcharts";
 
 export type AutoResize = boolean | {
   throttle?: number;
@@ -13,7 +13,7 @@ export function useAutoresize(chart: Ref<NullableValue<EChartsType>>, {
   autoresize,
   root
 }: {
-  echarts: MinifyEcharts;
+  echarts: CoreEcharts;
   autoresize: MaybeRefOrGetter<AutoResize>;
   root: Ref<NullableValue<ComponentPublicInstance>>;
 }): void {

--- a/packages/shared/src/composables/useEcharts.ts
+++ b/packages/shared/src/composables/useEcharts.ts
@@ -1,29 +1,15 @@
 import type * as Echarts from "echarts/core";
-import { init, registerPreprocessor, setPlatformAPI, throttle, use } from "echarts/core";
 import type { InjectionKey } from "vue";
 import { inject, provide } from "vue";
 
-export type MinifyEcharts = Pick<
-  typeof Echarts,
-  | "init"
-  | "registerPreprocessor"
-  | "setPlatformAPI"
-  | "throttle"
-  | "use"
->;
+export type CoreEcharts = typeof Echarts;
 
-export const ECHARTS_KEY: InjectionKey<MinifyEcharts> = Symbol("UniEcharts.echarts");
+export const ECHARTS_KEY: InjectionKey<CoreEcharts> = Symbol("UniEcharts.echarts");
 
-export function provideEcharts(echarts: MinifyEcharts): void {
+export function provideEcharts(echarts: CoreEcharts): void {
   provide(ECHARTS_KEY, echarts);
 }
 
-export function useEcharts(): MinifyEcharts {
-  return inject(ECHARTS_KEY, {
-    init,
-    registerPreprocessor,
-    setPlatformAPI,
-    use,
-    throttle
-  });
+export function useEcharts(): CoreEcharts {
+  return inject(ECHARTS_KEY)!;
 }

--- a/packages/shared/src/types/echarts.ts
+++ b/packages/shared/src/types/echarts.ts
@@ -1,7 +1,7 @@
-import type { init, SetOptionOpts } from "echarts/core";
+import type * as Echarts from "echarts/core";
 import type { Injection } from "./vue";
 
-type InitType = typeof init;
+type InitType = typeof Echarts["init"];
 export type InitParameters = Parameters<InitType>;
 
 export type ChartTheme = NonNullable<InitParameters[1]>;
@@ -10,7 +10,7 @@ export type ChartThemeInjection = Injection<ChartTheme>;
 export type InitOptions = NonNullable<InitParameters[2]>;
 export type InitOptionsInjection = Injection<InitOptions>;
 
-export type UpdateOptions = SetOptionOpts;
+export type UpdateOptions = Echarts.SetOptionOpts;
 export type UpdateOptionsInjection = Injection<UpdateOptions>;
 
 export type EChartsType = ReturnType<InitType>;

--- a/packages/shared/src/utils/canvas.ts
+++ b/packages/shared/src/utils/canvas.ts
@@ -1,4 +1,4 @@
-import type { MinifyEcharts } from "../composables";
+import type { CoreEcharts } from "../composables";
 import type { NullableValue, OptionalValue, ZRenderHandler } from "../types";
 import { defaultTo, isEmpty, lowerFirst, upperFirst } from "./helpers";
 import type { Emitter, EventType } from "./mitt";
@@ -363,7 +363,7 @@ export class UniImage {
 
 }
 
-export function setupEchartsCanvas(echarts: MinifyEcharts, {
+export function setupEchartsCanvas(echarts: CoreEcharts, {
   canvas,
   node
 }: {

--- a/playground/manifest.config.ts
+++ b/playground/manifest.config.ts
@@ -66,6 +66,13 @@ export default defineManifestConfig({
   "mp-weixin": {
     appid: "",
     setting: {
+      es6: false,
+      swc: true,
+      postcss: true,
+      minified: true,
+      minifyWXSS: true,
+      minifyWXML: true,
+      ignoreUploadUnusedFiles: true,
       urlCheck: false
     },
     optimization: {

--- a/playground/package.json
+++ b/playground/package.json
@@ -75,6 +75,7 @@
     "unocss": "catalog:style",
     "unocss-applet": "catalog:style",
     "unplugin-auto-import": "catalog:build",
+    "vite-plugin-inspect": "catalog:build",
     "vite-plugin-uni-polyfill": "catalog:build"
   }
 }

--- a/playground/pages.config.ts
+++ b/playground/pages.config.ts
@@ -6,6 +6,7 @@ export default defineUniPages({
       "^wd-(.*)": "wot-design-uni/components/wd-$1/wd-$1.vue"
     }
   },
+  tabBar: {},
   globalStyle: {
     navigationBarTitleText: "Uni ECharts",
     navigationBarTextStyle: "black",

--- a/playground/pages.config.ts
+++ b/playground/pages.config.ts
@@ -6,7 +6,6 @@ export default defineUniPages({
       "^wd-(.*)": "wot-design-uni/components/wd-$1/wd-$1.vue"
     }
   },
-  tabBar: {},
   globalStyle: {
     navigationBarTitleText: "Uni ECharts",
     navigationBarTextStyle: "black",

--- a/playground/src/manifest.json
+++ b/playground/src/manifest.json
@@ -54,7 +54,14 @@
   "mp-weixin": {
     "appid": "",
     "setting": {
-      "urlCheck": false
+      "urlCheck": false,
+      "es6": false,
+      "swc": true,
+      "postcss": true,
+      "minified": true,
+      "minifyWXSS": true,
+      "minifyWXML": true,
+      "ignoreUploadUnusedFiles": true
     },
     "usingComponents": true,
     "optimization": {

--- a/playground/src/pages.json
+++ b/playground/src/pages.json
@@ -4,6 +4,9 @@
       "^wd-(.*)": "wot-design-uni/components/wd-$1/wd-$1.vue"
     }
   },
+  "tabBar": {
+    "list": []
+  },
   "globalStyle": {
     "navigationBarTitleText": "Uni ECharts",
     "navigationBarTextStyle": "black",

--- a/playground/src/pages.json
+++ b/playground/src/pages.json
@@ -4,9 +4,6 @@
       "^wd-(.*)": "wot-design-uni/components/wd-$1/wd-$1.vue"
     }
   },
-  "tabBar": {
-    "list": []
-  },
   "globalStyle": {
     "navigationBarTitleText": "Uni ECharts",
     "navigationBarTextStyle": "black",

--- a/playground/src/pages/examples/action-dispatch/index.vue
+++ b/playground/src/pages/examples/action-dispatch/index.vue
@@ -35,8 +35,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   LegendComponent,
   TooltipComponent,

--- a/playground/src/pages/examples/async-data/index.vue
+++ b/playground/src/pages/examples/async-data/index.vue
@@ -51,8 +51,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   GridComponent,
   DatasetComponent,

--- a/playground/src/pages/examples/basic/index.vue
+++ b/playground/src/pages/examples/basic/index.vue
@@ -30,8 +30,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   LegendComponent,
   TooltipComponent,

--- a/playground/src/pages/examples/builtin-theme/index.vue
+++ b/playground/src/pages/examples/builtin-theme/index.vue
@@ -57,8 +57,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   LegendComponent,
   TooltipComponent,

--- a/playground/src/pages/examples/connectable/index.vue
+++ b/playground/src/pages/examples/connectable/index.vue
@@ -53,8 +53,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   LegendComponent,
   GridComponent,

--- a/playground/src/pages/examples/custom-tooltip/index.vue
+++ b/playground/src/pages/examples/custom-tooltip/index.vue
@@ -41,8 +41,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   TooltipComponent,
   DatasetComponent,

--- a/playground/src/pages/examples/export-image/index.vue
+++ b/playground/src/pages/examples/export-image/index.vue
@@ -38,8 +38,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   PolarComponent,
   LineChart,

--- a/playground/src/pages/examples/gradient/index.vue
+++ b/playground/src/pages/examples/gradient/index.vue
@@ -29,8 +29,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   LegendComponent,
   GridComponent,

--- a/playground/src/pages/examples/manual-update/index.vue
+++ b/playground/src/pages/examples/manual-update/index.vue
@@ -42,8 +42,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   TooltipComponent,
   ToolboxComponent,

--- a/playground/src/pages/examples/pinia-integration/index.vue
+++ b/playground/src/pages/examples/pinia-integration/index.vue
@@ -46,8 +46,6 @@ definePage({
   }
 });
 
-provideEcharts(echarts);
-
 echarts.use([
   RadarChart,
   CanvasRenderer

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -5,10 +5,12 @@ import UniComponents from "@uni-helper/vite-plugin-uni-components";
 import UniManifest from "@uni-helper/vite-plugin-uni-manifest";
 import UniPages from "@uni-helper/vite-plugin-uni-pages";
 import { UniEchartsResolver } from "uni-echarts/resolver";
+import { UniEcharts } from "uni-echarts/vite";
 import UnoCSS from "unocss/vite";
 import AutoImport from "unplugin-auto-import/vite";
 import type { PluginOption } from "vite";
 import { defineConfig } from "vite";
+import Inspect from "vite-plugin-inspect";
 import UniPolyfill from "vite-plugin-uni-polyfill";
 
 function r(...paths: string[]) {
@@ -73,6 +75,7 @@ function buildPlugins(): PluginOption[] {
         "**/components/**/*.*"
       ]
     }),
+    UniEcharts(),
     UniPolyfill(),
     Uni({
       vueOptions: {
@@ -81,7 +84,8 @@ function buildPlugins(): PluginOption[] {
         }
       }
     }),
-    UnoCSS()
+    UnoCSS(),
+    Inspect()
   ];
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ catalogs:
     '@types/lodash-es':
       specifier: ^4.17.12
       version: 4.17.12
+    '@types/node':
+      specifier: ^22.18.6
+      version: 22.18.6
   utils:
     '@antfu/utils':
       specifier: ^9.2.1
@@ -249,12 +252,15 @@ importers:
       '@types/fs-extra':
         specifier: catalog:types
         version: 11.0.4
+      '@types/node':
+        specifier: catalog:types
+        version: 22.18.6
       '@uni-helper/uni-app-types':
         specifier: catalog:dev
         version: 1.0.0-alpha.6(typescript@5.8.3)(vue@3.4.38(typescript@5.8.3))
       '@xiaohe01/eslint-config':
         specifier: catalog:lint
-        version: 2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0))
+        version: 2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0))
       '@xiaohe01/stylelint-config':
         specifier: catalog:lint
         version: 2.4.0(postcss@8.5.6)(stylelint@16.24.0(typescript@5.8.3))
@@ -308,10 +314,10 @@ importers:
         version: 3.5.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
       vite:
         specifier: catalog:build
-        version: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+        version: 5.4.20(@types/node@22.18.6)(terser@5.44.0)
       vitest:
         specifier: catalog:test
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0)
       vue-tsc:
         specifier: catalog:frontend
         version: 2.1.10(typescript@5.8.3)
@@ -2596,6 +2602,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@22.18.6':
+    resolution: {integrity: sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==}
 
   '@types/node@24.5.2':
     resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
@@ -6765,6 +6774,9 @@ packages:
   unconfig@7.3.3:
     resolution: {integrity: sha512-QCkQoOnJF8L107gxfHL0uavn7WD9b3dpBcFX6HtfQYmjw2YzWxGuFQ0N0J6tE9oguCBJn9KOvfqYDCMPHIZrBA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.12.0:
     resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
 
@@ -10029,7 +10041,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -10053,7 +10065,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   '@types/linkify-it@5.0.0': {}
 
@@ -10075,6 +10087,10 @@ snapshots:
   '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@22.18.6':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@24.5.2':
     dependencies:
@@ -10490,14 +10506,14 @@ snapshots:
       vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
-  '@vitest/eslint-plugin@1.3.12(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0))':
+  '@vitest/eslint-plugin@1.3.12(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.44.0
       '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
       eslint: 9.36.0(jiti@2.5.1)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10509,13 +10525,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@24.5.2)(terser@5.44.0))':
+  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@22.18.6)(terser@5.44.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(terser@5.44.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10782,7 +10798,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@xiaohe01/eslint-config@2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0))':
+  '@xiaohe01/eslint-config@2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
@@ -10791,7 +10807,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.4.0(eslint@9.36.0(jiti@2.5.1))
       '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
       '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
-      '@vitest/eslint-plugin': 1.3.12(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0))
+      '@vitest/eslint-plugin': 1.3.12(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0))
       ansis: 4.1.0
       cac: 6.7.14
       eslint: 9.36.0(jiti@2.5.1)
@@ -15095,6 +15111,8 @@ snapshots:
       jiti: 2.5.1
       quansync: 0.2.11
 
+  undici-types@6.21.0: {}
+
   undici-types@7.12.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -15315,13 +15333,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.5.2)(terser@5.44.0):
+  vite-node@3.2.4(@types/node@22.18.6)(terser@5.44.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(terser@5.44.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15350,6 +15368,16 @@ snapshots:
       - supports-color
 
   vite-plugin-uni-polyfill@0.1.0: {}
+
+  vite@5.4.20(@types/node@22.18.6)(terser@5.44.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.0
+    optionalDependencies:
+      '@types/node': 22.18.6
+      fsevents: 2.3.3
+      terser: 5.44.0
 
   vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0):
     dependencies:
@@ -15439,11 +15467,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@24.5.2)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@22.18.6)(terser@5.44.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -15461,12 +15489,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
-      vite-node: 3.2.4(@types/node@24.5.2)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(terser@5.44.0)
+      vite-node: 3.2.4(@types/node@22.18.6)(terser@5.44.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       jsdom: 16.7.0
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,131 @@ settings:
 catalogs:
   build:
     '@uni-helper/vite-plugin-uni-components':
-      specifier: ^0.2.0
-      version: 0.2.0
+      specifier: ^0.2.1
+      version: 0.2.1
+    '@uni-helper/vite-plugin-uni-manifest':
+      specifier: ^0.2.8
+      version: 0.2.8
+    '@uni-helper/vite-plugin-uni-pages':
+      specifier: ^0.3.15
+      version: 0.3.15
+    unbuild:
+      specifier: ~3.5.0
+      version: 3.5.0
+    unplugin-auto-import:
+      specifier: ^20.1.0
+      version: 20.1.0
+    vite:
+      specifier: ^5.4.20
+      version: 5.4.20
+    vite-plugin-inspect:
+      specifier: ~0.8.9
+      version: 0.8.9
+    vite-plugin-uni-polyfill:
+      specifier: ^0.1.0
+      version: 0.1.0
+    vitepress:
+      specifier: ^1.6.4
+      version: 1.6.4
+    vitepress-plugin-group-icons:
+      specifier: ^1.6.3
+      version: 1.6.3
+    vitepress-plugin-llms:
+      specifier: ^1.7.5
+      version: 1.7.5
+  cli:
+    bumpp:
+      specifier: ^10.2.3
+      version: 10.2.3
+    pncat:
+      specifier: ^0.5.4
+      version: 0.5.4
+  dcloudio:
+    '@dcloudio/types':
+      specifier: ^3.4.21
+      version: 3.4.21
+    '@dcloudio/uni-app':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-app-harmony':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-app-plus':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-automator':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-cli-shared':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-components':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-h5':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-alipay':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-baidu':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-jd':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-kuaishou':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-lark':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-qq':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-toutiao':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-weixin':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-mp-xhs':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-quickapp-webview':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/uni-stacktracey':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
+    '@dcloudio/vite-plugin-uni':
+      specifier: 3.0.0-4070620250821001
+      version: 3.0.0-4070620250821001
   dev:
+    '@antfu/ni':
+      specifier: ^26.0.1
+      version: 26.0.1
+    '@mini-types/alipay':
+      specifier: ^3.0.14
+      version: 3.0.14
+    '@uni-helper/plugin-uni':
+      specifier: ^0.1.0
+      version: 0.1.0
+    '@uni-helper/uni-app-types':
+      specifier: ^1.0.0-alpha.6
+      version: 1.0.0-alpha.6
+    '@xiaohe01/tsconfig':
+      specifier: ^2.0.0
+      version: 2.0.0
+    miniprogram-api-typings:
+      specifier: ^4.1.0
+      version: 4.1.0
     oxc-parser:
-      specifier: ^0.89.0
-      version: 0.89.0
+      specifier: ^0.90.0
+      version: 0.90.0
+    typescript:
+      specifier: ~5.8.3
+      version: 5.8.3
   frontend:
     '@vue/runtime-core':
       specifier: ~3.4.38
@@ -20,6 +139,92 @@ catalogs:
     echarts:
       specifier: ^5.6.0
       version: 5.6.0
+    pinia:
+      specifier: 2.2.4
+      version: 2.2.4
+    vue-tsc:
+      specifier: ~2.1.10
+      version: 2.1.10
+    wot-design-uni:
+      specifier: ^1.12.4
+      version: 1.12.4
+  icons:
+    '@iconify-json/carbon':
+      specifier: ^1.2.13
+      version: 1.2.13
+  lint:
+    '@xiaohe01/eslint-config':
+      specifier: ^2.3.0
+      version: 2.3.0
+    '@xiaohe01/stylelint-config':
+      specifier: ^2.4.0
+      version: 2.4.0
+    eslint:
+      specifier: ^9.36.0
+      version: 9.36.0
+    lint-staged:
+      specifier: ^16.1.6
+      version: 16.1.6
+    simple-git-hooks:
+      specifier: ^2.13.1
+      version: 2.13.1
+    stylelint:
+      specifier: ^16.24.0
+      version: 16.24.0
+  node:
+    chalk:
+      specifier: ^5.6.2
+      version: 5.6.2
+    consola:
+      specifier: ^3.4.2
+      version: 3.4.2
+    execa:
+      specifier: ^9.6.0
+      version: 9.6.0
+    fs-extra:
+      specifier: ^11.3.2
+      version: 11.3.2
+    rimraf:
+      specifier: ^6.0.1
+      version: 6.0.1
+  script:
+    esno:
+      specifier: ^4.8.0
+      version: 4.8.0
+  style:
+    '@uni-helper/unocss-preset-uni':
+      specifier: ^0.2.11
+      version: 0.2.11
+    sass:
+      specifier: ~1.78.0
+      version: 1.78.0
+    unocss:
+      specifier: ~66.0.0
+      version: 66.0.0
+    unocss-applet:
+      specifier: ^0.11.0
+      version: 0.11.0
+  test:
+    vitest:
+      specifier: ^3.2.4
+      version: 3.2.4
+  types:
+    '@types/fs-extra':
+      specifier: ^11.0.4
+      version: 11.0.4
+    '@types/lodash-es':
+      specifier: ^4.17.12
+      version: 4.17.12
+  utils:
+    '@antfu/utils':
+      specifier: ^9.2.1
+      version: 9.2.1
+    '@vueuse/core':
+      specifier: ^12.8.2
+      version: 12.8.2
+    lodash-es:
+      specifier: ^4.17.21
+      version: 4.17.21
 
 overrides:
   mkdist: 2.3.0
@@ -31,10 +236,10 @@ importers:
     devDependencies:
       '@antfu/ni':
         specifier: catalog:dev
-        version: 25.0.0
+        version: 26.0.1
       '@antfu/utils':
         specifier: catalog:utils
-        version: 9.2.0
+        version: 9.2.1
       '@dcloudio/types':
         specifier: catalog:dcloudio
         version: 3.4.21
@@ -49,7 +254,7 @@ importers:
         version: 1.0.0-alpha.6(typescript@5.8.3)(vue@3.4.38(typescript@5.8.3))
       '@xiaohe01/eslint-config':
         specifier: catalog:lint
-        version: 2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0))
+        version: 2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0))
       '@xiaohe01/stylelint-config':
         specifier: catalog:lint
         version: 2.4.0(postcss@8.5.6)(stylelint@16.24.0(typescript@5.8.3))
@@ -67,7 +272,7 @@ importers:
         version: 3.4.2
       eslint:
         specifier: catalog:lint
-        version: 9.35.0(jiti@2.5.1)
+        version: 9.36.0(jiti@2.5.1)
       esno:
         specifier: catalog:script
         version: 4.8.0
@@ -103,10 +308,10 @@ importers:
         version: 3.5.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
       vite:
         specifier: catalog:build
-        version: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+        version: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
       vitest:
         specifier: catalog:test
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0)
       vue-tsc:
         specifier: catalog:frontend
         version: 2.1.10(typescript@5.8.3)
@@ -115,10 +320,10 @@ importers:
     devDependencies:
       vitepress:
         specifier: catalog:build
-        version: 1.6.4(@algolia/client-search@5.37.0)(@types/node@24.5.1)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2)
+        version: 1.6.4(@algolia/client-search@5.37.0)(@types/node@24.5.2)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2)
       vitepress-plugin-group-icons:
         specifier: catalog:build
-        version: 1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
+        version: 1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
       vitepress-plugin-llms:
         specifier: catalog:build
         version: 1.7.5
@@ -130,7 +335,7 @@ importers:
     devDependencies:
       '@uni-helper/vite-plugin-uni-components':
         specifier: catalog:build
-        version: 0.2.0(rollup@4.50.2)
+        version: 0.2.1(rollup@4.52.0)
       '@vue/runtime-core':
         specifier: catalog:frontend
         version: 3.4.38
@@ -139,7 +344,7 @@ importers:
         version: 5.6.0
       oxc-parser:
         specifier: catalog:dev
-        version: 0.89.0
+        version: 0.90.0
       vue:
         specifier: 3.4.38
         version: 3.4.38(typescript@5.9.2)
@@ -160,49 +365,49 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-harmony':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-plus':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-components':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-h5':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-alipay':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-baidu':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-jd':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-kuaishou':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-lark':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-qq':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-toutiao':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-weixin':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-xhs':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-quickapp-webview':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@vueuse/core':
         specifier: catalog:utils
         version: 12.8.2(typescript@5.9.2)
@@ -227,16 +432,16 @@ importers:
     devDependencies:
       '@dcloudio/uni-automator':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-cli-shared':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-stacktracey':
         specifier: catalog:dcloudio
         version: 3.0.0-4070620250821001
       '@dcloudio/vite-plugin-uni':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@iconify-json/carbon':
         specifier: catalog:icons
         version: 1.2.13
@@ -245,19 +450,19 @@ importers:
         version: 4.17.12
       '@uni-helper/plugin-uni':
         specifier: catalog:dev
-        version: 0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       '@uni-helper/unocss-preset-uni':
         specifier: catalog:style
-        version: 0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       '@uni-helper/vite-plugin-uni-components':
         specifier: catalog:build
-        version: 0.2.0(rollup@4.50.2)
+        version: 0.2.1(rollup@4.52.0)
       '@uni-helper/vite-plugin-uni-manifest':
         specifier: catalog:build
-        version: 0.2.8(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
+        version: 0.2.8(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
       '@uni-helper/vite-plugin-uni-pages':
         specifier: catalog:build
-        version: 0.3.14(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
+        version: 0.3.15(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
       '@vue/runtime-core':
         specifier: catalog:frontend
         version: 3.4.38
@@ -266,16 +471,16 @@ importers:
         version: 1.78.0
       unocss:
         specifier: catalog:style
-        version: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       unocss-applet:
         specifier: catalog:style
-        version: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       unplugin-auto-import:
         specifier: catalog:build
         version: 20.1.0(@vueuse/core@12.8.2(typescript@5.9.2))
       vite-plugin-inspect:
         specifier: catalog:build
-        version: 0.8.9(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
+        version: 0.8.9(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
       vite-plugin-uni-polyfill:
         specifier: catalog:build
         version: 0.1.0
@@ -365,8 +570,9 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@antfu/ni@25.0.0':
-    resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
+  '@antfu/ni@26.0.1':
+    resolution: {integrity: sha512-yGtjrmEVziDXW/7ggkzDtJkiJ8e8a9j+CtYBhT6gnvVoIXHtTc+iL+ZDMfUDe1wxRvYJrLpmHLJb5HjA5Hskyg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   '@antfu/utils@0.7.10':
@@ -375,8 +581,8 @@ packages:
   '@antfu/utils@8.1.1':
     resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
 
-  '@antfu/utils@9.2.0':
-    resolution: {integrity: sha512-Oq1d9BGZakE/FyoEtcNeSwM7MpDO2vUBi11RWBZXf75zPsbUVWmUs03EqkRFrcgbXyKTas0BdZWC1wcuSoqSAw==}
+  '@antfu/utils@9.2.1':
+    resolution: {integrity: sha512-TMilPqXyii1AsiEii6l6ubRzbo76p6oshUSYPaKsmXDavyMLqjzVDkcp3pHp5ELMUNJHATcEOGxKTTsX9yYhGg==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1175,8 +1381,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.25.9':
-    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -1193,8 +1399,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.25.9':
-    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1211,8 +1417,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.25.9':
-    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -1229,8 +1435,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.25.9':
-    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1247,8 +1453,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.25.9':
-    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -1265,8 +1471,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.9':
-    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1283,8 +1489,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.25.9':
-    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -1301,8 +1507,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.9':
-    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1319,8 +1525,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.25.9':
-    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -1337,8 +1543,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.9':
-    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1355,8 +1561,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.9':
-    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -1373,8 +1579,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.9':
-    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1391,8 +1597,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.9':
-    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -1409,8 +1615,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.9':
-    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1427,8 +1633,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.9':
-    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -1445,8 +1651,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.9':
-    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1463,14 +1669,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.9':
-    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1487,14 +1693,14 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.9':
-    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1511,14 +1717,14 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.9':
-    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.9':
-    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1535,8 +1741,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.25.9':
-    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1553,8 +1759,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.25.9':
-    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1571,8 +1777,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.9':
-    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -1589,8 +1795,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.9':
-    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1636,8 +1842,8 @@ packages:
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.35.0':
-    resolution: {integrity: sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==}
+  '@eslint/js@9.36.0':
+    resolution: {integrity: sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/markdown@7.2.0':
@@ -1975,9 +2181,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@keyv/bigmap@1.0.0':
-    resolution: {integrity: sha512-N2UsRSXlWwbvYKdFVS7sKqj6oXGegELh+zr9VripWDc8grsq8KBNp8JHI+9AQuUEFiM1S7+tm6lLp/lmbBCqCw==}
-    engines: {node: '>= 20'}
+  '@keyv/bigmap@1.0.2':
+    resolution: {integrity: sha512-KR03xkEZlAZNF4IxXgVXb+uNIVNvwdh8UwI0cnc7WI6a+aQcDp8GL80qVfeB4E5NpsKJzou5jU0r6yLSSbMOtA==}
+    engines: {node: '>= 18'}
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
@@ -2006,103 +2212,97 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-parser/binding-android-arm64@0.89.0':
-    resolution: {integrity: sha512-Tz0FoCIU/MGteWnCLk8UjN6EgNCnFO/HPrf6/Slg2snFYBaEv4kQVSfe5uN6DWlhuX0/Hk891bJif7kvQkXskg==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-android-arm64@0.90.0':
+    resolution: {integrity: sha512-0po5R8DKsMujj9COlJxzonn/BhnXN4ZTN8+L3D5J3nTYkEhL06yLwgZCxAHWwqO85mfQvfMFiInVjcLeJWwXhQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-darwin-arm64@0.89.0':
-    resolution: {integrity: sha512-kypXATIbctk9djDWXuC7XGbfOgiNJgYpIHIN7lyIhEqYvvrpmSiRaufn2zIjzDxmJFyok4A7wHJH7LsNwrOZhw==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-darwin-arm64@0.90.0':
+    resolution: {integrity: sha512-TbO8qXB0KbgRdja2UsDeIW7KMFYE5guWXucXR8fZ5W9O9RQMZmGRNQpFgoQ4gd0bvItka8E5XimP7EI79NQXSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.89.0':
-    resolution: {integrity: sha512-0mBLPC7LH6FCTfpq8vjZ12ZevOPN8XvrxV6zIyUlW2Xv/s4AJ5myn1Vqy3g0kCJYVoyTNWOLHzkTp2uDx0VQOw==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-darwin-x64@0.90.0':
+    resolution: {integrity: sha512-MOUs6wdlwbjdI32z+DfEAjBL/ds7TA5uDRTlzajkRtgtpTJoIdNrvSyG7ndRK4pW72pohQhX5GSRSjKkeoaEMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-freebsd-x64@0.89.0':
-    resolution: {integrity: sha512-UWQai6zd3+w+Z7iRHkw8ZD5dwrlAWkbsBmK7nfNHwOa9gew/J10iS7aatX0YQ8MzpUVa5wIofGmB4kOoG/IzFg==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-freebsd-x64@0.90.0':
+    resolution: {integrity: sha512-sBXVswFVSCQnxr4iKgHyF8D3E3lpvlgZhwK2jfhsO8sfEkETeAQUtuHixN6IH7KVAX7YpdeXQy0UT9mUbvuCIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.89.0':
-    resolution: {integrity: sha512-vfi2bef+VMp0bcPomQugQcpEe4GpYKhT2HFCgUplEMneQNuPj5z/rF6u1Ix0y13MisO8cbNhxP0oB1tvqmPA6Q==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.90.0':
+    resolution: {integrity: sha512-teB+KYJU/9BfkHA5wY0S5OTwcmVogltq+ycRIxUEQ6oyXYqlDHZHIrSDbQjtlxwSn4fbZu9cL58K0eQ9XNRHkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.89.0':
-    resolution: {integrity: sha512-EvLiLQSYkBTtp8c91bjBCxlf0rMIq3jfcYopEx5jz9lv/nhJGrxkzVvj0kAN3f2iufbkk0PygKkSvQx0Kpy9zQ==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.90.0':
+    resolution: {integrity: sha512-HIQNBFxMWMqKWARJUj5lzX19jN9CFjMBjS3fji98xvPGixk712fL7YXmV7E1V6Wx+iRJcGwH/UrZBVTT28MWqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.89.0':
-    resolution: {integrity: sha512-jeI7qoHvvUIqLCN4FAPmTLpcQrlL3cuteH0HuYBmeVdBcJyPLAWAht7EaDlPjYOFvp4e9Tp3IqrpdqCztCWdAw==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-linux-arm64-gnu@0.90.0':
+    resolution: {integrity: sha512-06l5M3U8fj/V1pscAU6Rqh4YdCD5NqLxIZRZFFq4+8Bm3oeGMaZK0LxWYaqNUMWBaaF7dHpdP8GwLxGdFJ6UvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.89.0':
-    resolution: {integrity: sha512-Pxe89cKhKNvHm6eii1zWr711sEyxFzJxINYAP5SM7PgajQb9dZq8Le0e68NYADlsoXVc/zcYlo+aC2yhjxNMVA==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-linux-arm64-musl@0.90.0':
+    resolution: {integrity: sha512-tvUIddTl8I9MDDzvsF3tII4zj0obyMyKemp4LrrqZsBCwrq8Dwh9gH7OCdv3bA2f42xI0/wIAYanleJQD1SDUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.89.0':
-    resolution: {integrity: sha512-g9R9Uph7gi9SBYKop5SdNK3c9WCBZSeYkE3IU3dF5DZnR/xqBkVRKnc+LAuboijEhhqLw4XwbQ49Wd6cBDjSTg==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.90.0':
+    resolution: {integrity: sha512-Dh81QQbBX9V1FOpc/9MOuWxWeSrDJ271xCW93JScuiMP7zK0KtgFA4UGCYzzMBukIcGa0F22uSkLGrflllkTTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.89.0':
-    resolution: {integrity: sha512-RFalRHelX4EFJcp3Byy4z5ZnYoEFSlRmgZECYfr/7yPSmo79DKL2VEHeVzIAKFbfTOPDIm0yw9BbUEBDritWDQ==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-linux-s390x-gnu@0.90.0':
+    resolution: {integrity: sha512-YxRkh2Ze8l/qfuMk2A6MQVQBtdDcuFJ30JKMH7WDLlUdHKIvHaND1LxqSaATES2k3p+CUd7CsVpJcGQh4jq5Pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.89.0':
-    resolution: {integrity: sha512-BjU07UxFMSm0/7c79KBBCC2Meef45CQ7dg068xLK6voZgEY24NNq2F0xfl7FxBrymR/viluSP5gopQYjHXqc4A==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-linux-x64-gnu@0.90.0':
+    resolution: {integrity: sha512-0uQTO5UDcQcSucFoiLBAP0YQpDMLGnkLX1PsQaaArXubJcPq0AhB5QHesYNCFvFyHb7f1cdr62nVX6pTuY6isw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-musl@0.89.0':
-    resolution: {integrity: sha512-RLecF47V/uy3voAt2BFywfh1RUtHlgdz/oG9oMG0E+A/3ZQPTEB1WuJyAnDsC0anxQS5W2J+/az3l5sL4/n54w==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-linux-x64-musl@0.90.0':
+    resolution: {integrity: sha512-dA7O+xYmSTaYvfhFePDc1mhE98Brb5cyc+Gqc4KvDLc2aejLDk4GpMVKle1kqOt8F01DI0OnRqNLrzkYW7tDww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@oxc-parser/binding-wasm32-wasi@0.89.0':
-    resolution: {integrity: sha512-h9uyojS96as3+KnvQ6MojTBHeHTpN88ejzoNxEcUbhgupIYTCp59G+5BQh7E+w4lrCuGmnjphFkca07RvWQpbQ==}
+  '@oxc-parser/binding-wasm32-wasi@0.90.0':
+    resolution: {integrity: sha512-eqJUW+dRkzgpiY3Sdcr4rMyANYCxTyYH69V074ftoIWNTvWU30dWCkpV/kUNbsn3uivjdJH9nQhxHG29putZSw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.89.0':
-    resolution: {integrity: sha512-OGa7mETyx7Mg0ecLQraawzRrVQDinNP7WQQ7CjDD/Y1YgKM/8oN9xa5TaVe5dh66pbKOz49NJ4LccaUs58UaMQ==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-win32-arm64-msvc@0.90.0':
+    resolution: {integrity: sha512-nDQeb/KdTkNe2tYw6cc8xs222hg6KSA8T9HwJfKXdWhkmbIxm6TRob2HLtaJSrnX21n+Sv5u675POc17Jy5ANQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.89.0':
-    resolution: {integrity: sha512-uNRWb1VNW/OiJf26rc6XY63kRoHmIXMpsKFjECTGIfaxwNDKx/mtJSvLQaFDZxoWuY9VsNrtOqNidgkYeW3tfQ==}
-    engines: {node: '>=20.0.0'}
+  '@oxc-parser/binding-win32-x64-msvc@0.90.0':
+    resolution: {integrity: sha512-/suQV2+qhl6RT/19Zej6jVWYa6KauXkNLjnC4PDiA0QZj25B8JbYdnXqkIstet3whSFWDYXF/Fhzuz0cpC8BZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxc-project/types@0.89.0':
-    resolution: {integrity: sha512-yuo+ECPIW5Q9mSeNmCDC2im33bfKuwW18mwkaHMQh8KakHYDzj4ci/q7wxf2qS3dMlVVCIyrs3kFtH5LmnlYnw==}
+  '@oxc-project/types@0.90.0':
+    resolution: {integrity: sha512-fWvaufWUcLtm/OBKcNmxUkR0kQW5ZKAF0t03BXPqdzpxmnVCmSKzvUDRCOKnSagSfNzG/3ZdKpComH3GMy881g==}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -2168,119 +2368,113 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.50.2':
-    resolution: {integrity: sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==}
+  '@rollup/rollup-android-arm-eabi@4.52.0':
+    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.50.2':
-    resolution: {integrity: sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==}
+  '@rollup/rollup-android-arm64@4.52.0':
+    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.50.2':
-    resolution: {integrity: sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==}
+  '@rollup/rollup-darwin-arm64@4.52.0':
+    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.50.2':
-    resolution: {integrity: sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==}
+  '@rollup/rollup-darwin-x64@4.52.0':
+    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.50.2':
-    resolution: {integrity: sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==}
+  '@rollup/rollup-freebsd-arm64@4.52.0':
+    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.50.2':
-    resolution: {integrity: sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==}
+  '@rollup/rollup-freebsd-x64@4.52.0':
+    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.50.2':
-    resolution: {integrity: sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.50.2':
-    resolution: {integrity: sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.50.2':
-    resolution: {integrity: sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==}
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.50.2':
-    resolution: {integrity: sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==}
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
+    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.50.2':
-    resolution: {integrity: sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==}
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.50.2':
-    resolution: {integrity: sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==}
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.50.2':
-    resolution: {integrity: sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==}
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.50.2':
-    resolution: {integrity: sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==}
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.50.2':
-    resolution: {integrity: sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==}
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.50.2':
-    resolution: {integrity: sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==}
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.50.2':
-    resolution: {integrity: sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==}
+  '@rollup/rollup-linux-x64-musl@4.52.0':
+    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@rollup/rollup-openharmony-arm64@4.50.2':
-    resolution: {integrity: sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==}
+  '@rollup/rollup-openharmony-arm64@4.52.0':
+    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.50.2':
-    resolution: {integrity: sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==}
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.50.2':
-    resolution: {integrity: sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==}
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.50.2':
-    resolution: {integrity: sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==}
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
+    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
     cpu: [x64]
     os: [win32]
 
@@ -2321,8 +2515,8 @@ packages:
   '@sinonjs/fake-timers@8.1.0':
     resolution: {integrity: sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==}
 
-  '@stylistic/eslint-plugin@5.3.1':
-    resolution: {integrity: sha512-Ykums1VYonM0TgkD0VteVq9mrlO2FhF48MDJnPyv3MktIB2ydtuhlO0AfWm7xnW1kyf5bjOqA6xc7JjviuVTxg==}
+  '@stylistic/eslint-plugin@5.4.0':
+    resolution: {integrity: sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=9.0.0'
@@ -2403,8 +2597,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.5.1':
-    resolution: {integrity: sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==}
+  '@types/node@24.5.2':
+    resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
 
   '@types/prettier@2.7.3':
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
@@ -2519,16 +2713,16 @@ packages:
       '@unocss/vite':
         optional: true
 
-  '@uni-helper/vite-plugin-uni-components@0.2.0':
-    resolution: {integrity: sha512-h/rV8Z3N+wus/ZviYzkdRePNSUlkndn5H+wVC17ZXmG+2mqmUfLJdGskzrCbgE7Y1TT7u8E9yMz8Ah/RwMf0GQ==}
+  '@uni-helper/vite-plugin-uni-components@0.2.1':
+    resolution: {integrity: sha512-9PQl3NhCkLUboJl+YB8zAnuLV3WKU/oQgtRL1DZFIZ6iJuf6E9EWrCMvD9dB+WG6mP1wjNages9mopVfL8yZeA==}
 
   '@uni-helper/vite-plugin-uni-manifest@0.2.8':
     resolution: {integrity: sha512-6QtUcCTkvpR5GAPUxyKlEtm+KYxOk1RSVfdrxlWYW2q7Iws0D7UeNirA4GMuc/SaayEjURlU7cUrS7NceoPCfQ==}
     peerDependencies:
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  '@uni-helper/vite-plugin-uni-pages@0.3.14':
-    resolution: {integrity: sha512-CR/Are/3K4KebMkNaIjS0VzrNwhEX79Ve/SBuVZSqrXVNvo8dSOP4JHbgmOPaMgPypZlO6mN7HibOP/0crySXw==}
+  '@uni-helper/vite-plugin-uni-pages@0.3.15':
+    resolution: {integrity: sha512-0jCJp9DRRusEhasCcEgTlW5hiKWaaz3x9wlMwz3GbmPVL7UziMRufNHnwlu42Z7CXU4soKbDFv+8qYIcxEJZnQ==}
     peerDependencies:
       vite: ^5.0.0
 
@@ -3138,8 +3332,8 @@ packages:
     resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
     engines: {node: '>=6.0.0'}
 
-  baseline-browser-mapping@2.8.4:
-    resolution: {integrity: sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==}
+  baseline-browser-mapping@2.8.6:
+    resolution: {integrity: sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==}
     hasBin: true
 
   binary-extensions@2.3.0:
@@ -3467,8 +3661,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-declaration-sorter@7.2.0:
-    resolution: {integrity: sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==}
+  css-declaration-sorter@7.3.0:
+    resolution: {integrity: sha512-LQF6N/3vkAMYF4xoHLJfG718HRJh34Z8BnNhd6bosOMIVjMlhuZK5++oZa3uYAgrI5+7x2o27gUqTR2U/KjUOQ==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
@@ -3700,8 +3894,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.219:
-    resolution: {integrity: sha512-JqaXfxHOS0WvKweEnrPHWRm8cnPVbdB7vXCQHPPFoAJFM3xig5/+/H08ZVkvJf4unvj8yncKy6MerOPj1NW1GQ==}
+  electron-to-chromium@1.5.222:
+    resolution: {integrity: sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==}
 
   emittery@0.8.1:
     resolution: {integrity: sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==}
@@ -3782,8 +3976,8 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.25.9:
-    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3832,8 +4026,8 @@ packages:
     peerDependencies:
       eslint: ^9.5.0
 
-  eslint-flat-config-utils@2.1.1:
-    resolution: {integrity: sha512-K8eaPkBemHkfbYsZH7z4lZ/tt6gNSsVh535Wh9W9gQBS2WjvfUbbVr2NZR3L1yiRCLuOEimYfPxCxODczD4Opg==}
+  eslint-flat-config-utils@2.1.4:
+    resolution: {integrity: sha512-bEnmU5gqzS+4O+id9vrbP43vByjF+8KOs+QuuV4OlqAuXmnRW2zfI/Rza1fQvdihQ5h4DUo0NqFAiViD4mSrzQ==}
 
   eslint-json-compat-utils@0.2.1:
     resolution: {integrity: sha512-YzEodbDyW8DX8bImKhAcCeu/L31Dd/70Bidx2Qex9OFUtgzXLqtfWL4Hr5fM/aCCB8QUZLuJur0S9k6UfgFkfg==}
@@ -3889,8 +4083,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-plugin-n@17.23.0:
-    resolution: {integrity: sha512-aPePGxUr5LezcXmMRBF83eK1MmqUYY1NdLdHC+jdpfc5b98eL7yDXY20gXJ6DcTxrHBhrLsfYYqo7J+m0h9YXQ==}
+  eslint-plugin-n@17.23.1:
+    resolution: {integrity: sha512-68PealUpYoHOBh332JLLD9Sj7OQUDkFpmcfqt8R9sySfFSeuGJjMTJQvCRRB96zO3A/PELRLkPrzsHmzEFQQ5A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.23.0'
@@ -3972,8 +4166,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.35.0:
-    resolution: {integrity: sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==}
+  eslint@9.36.0:
+    resolution: {integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -4372,8 +4566,8 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
-  hookified@1.12.0:
-    resolution: {integrity: sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ==}
+  hookified@1.12.1:
+    resolution: {integrity: sha512-xnKGl+iMIlhrZmGHB729MqlmPoWBznctSQTYCpFKqNsCgimJQmithcW0xSQMMFzYnV2iKUh25alswn6epgxS0Q==}
 
   html-encoding-sniffer@2.0.1:
     resolution: {integrity: sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==}
@@ -4818,8 +5012,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonc-eslint-parser@2.4.0:
-    resolution: {integrity: sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==}
+  jsonc-eslint-parser@2.4.1:
+    resolution: {integrity: sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   jsonc-parser@3.3.1:
@@ -4831,8 +5025,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  keyv@5.5.1:
-    resolution: {integrity: sha512-eF3cHZ40bVsjdlRi/RvKAuB0+B61Q1xWvohnrJrnaQslM3h1n79IV+mc9EGag4nrA9ZOlNyr3TUzW5c8uy8vNA==}
+  keyv@5.5.2:
+    resolution: {integrity: sha512-TXcFHbmm/z7MGd1u9ASiCSfTS+ei6Z8B3a5JHzx3oPa/o7QzWVtPRpc4KGER5RR469IC+/nfg4U5YLIuDUua2g==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -5398,9 +5592,9 @@ packages:
     resolution: {integrity: sha512-Sv0OvhPiMutICiwORAUefv02DCPb62IelBmo8ZsSrRHyI3FStqIWZvjqDkvtjU+lcujo7UNir+dCwKSqlEQ/5w==}
     engines: {node: '>=10', yarn: ^1.22.4}
 
-  oxc-parser@0.89.0:
-    resolution: {integrity: sha512-BO/RxfooJxuoofjC1USPmZ9a32pzjwXFAM1MHO2zPSij9fkgngHMzAu4t8XY1zrXMmoLBv13fh6LUZ906Rjx+g==}
-    engines: {node: '>=20.0.0'}
+  oxc-parser@0.90.0:
+    resolution: {integrity: sha512-EdLFy70OU/V9mhyUwrsx+ohH+HcOuxCjmMktSnz6RI5dgATAHO7qTfRTbyjcMdzeZUXUI4ep2g16sFPNFPeDlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -5883,8 +6077,8 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
-  pretty-bytes@7.0.1:
-    resolution: {integrity: sha512-285/jRCYIbMGDciDdrw0KPNC4LKEEwz/bwErcYNxSJOi4CpGUuLpb9gQpg3XJP0XYj9ldSRluXxih4lX2YN8Xw==}
+  pretty-bytes@7.1.0:
+    resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
 
   pretty-format@27.5.1:
@@ -6090,8 +6284,8 @@ packages:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0
 
-  rollup@4.50.2:
-    resolution: {integrity: sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==}
+  rollup@4.52.0:
+    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -6459,8 +6653,8 @@ packages:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@4.0.3:
-    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
@@ -6605,8 +6799,8 @@ packages:
     resolution: {integrity: sha512-j9+fijH6aDd05yv1fXlyt7HSxtOWtGtrZeYTVBsSUg57Iuf+Ps2itIZjeyu7bEQ4k0WOgYhHrdW8m/pJgOpl5g==}
     engines: {node: '>=18.12.0'}
 
-  unimport@5.2.0:
-    resolution: {integrity: sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==}
+  unimport@5.3.0:
+    resolution: {integrity: sha512-cty7t1DESgm0OPfCy9oyn5u9B5t0tMW6tH6bXTjAGIO3SkJsbg/DXYHjrPrUKqultqbAAoltAfYsuu/FEDocjg==}
     engines: {node: '>=18.12.0'}
 
   unist-util-is@6.0.0:
@@ -7199,18 +7393,19 @@ snapshots:
       package-manager-detector: 1.3.0
       tinyexec: 1.0.1
 
-  '@antfu/ni@25.0.0':
+  '@antfu/ni@26.0.1':
     dependencies:
       ansis: 4.1.0
       fzf: 0.5.2
       package-manager-detector: 1.3.0
       tinyexec: 1.0.1
+      tinyglobby: 0.2.15
 
   '@antfu/utils@0.7.10': {}
 
   '@antfu/utils@8.1.1': {}
 
-  '@antfu/utils@9.2.0': {}
+  '@antfu/utils@9.2.1': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -7967,9 +8162,9 @@ snapshots:
     dependencies:
       '@cacheable/memoize': 2.0.1
       '@cacheable/utils': 2.0.1
-      '@keyv/bigmap': 1.0.0
-      hookified: 1.12.0
-      keyv: 5.5.1
+      '@keyv/bigmap': 1.0.2
+      hookified: 1.12.1
+      keyv: 5.5.2
 
   '@cacheable/utils@2.0.1': {}
 
@@ -8001,10 +8196,10 @@ snapshots:
 
   '@dcloudio/types@3.4.21': {}
 
-  '@dcloudio/uni-app-harmony@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-harmony@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       debug: 4.4.3
       fs-extra: 10.1.0
       licia: 1.48.0
@@ -8019,10 +8214,10 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-plus@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-plus@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-vue': 3.0.0-4070620250821001
       debug: 4.4.3
       fs-extra: 10.1.0
@@ -8038,18 +8233,18 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-uts@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-uts@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-nvue-styler': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -8073,14 +8268,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-app-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-nvue-styler': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       debug: 4.4.3
@@ -8098,16 +8293,16 @@ snapshots:
 
   '@dcloudio/uni-app-vue@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-app@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@dcloudio/types': 3.4.21
-      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-components': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-components': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
-      '@dcloudio/uni-push': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-push': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@dcloudio/uni-stat': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-stat': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@vue/shared': 3.4.21
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8118,9 +8313,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-automator@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-automator@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       address: 1.2.2
       cross-env: 7.0.3
       debug: 4.4.3
@@ -8145,7 +8340,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-cli-shared@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-cli-shared@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
@@ -8157,7 +8352,7 @@ snapshots:
       '@intlify/core-base': 9.1.9
       '@intlify/shared': 9.1.9
       '@intlify/vue-devtools': 9.1.9
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -8205,9 +8400,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cloud@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-cloud@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8221,10 +8416,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-components@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-components@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-h5': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-h5': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8235,9 +8430,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-console@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-console@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8248,11 +8443,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-h5-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-h5-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/server-renderer': 3.4.21(vue@3.4.38(typescript@5.9.2))
@@ -8277,9 +8472,9 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@dcloudio/uni-h5@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-h5@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-h5-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-h5-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-h5-vue': 3.0.0-4070620250821001(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
@@ -8302,10 +8497,10 @@ snapshots:
 
   '@dcloudio/uni-i18n@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-mp-alipay@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-alipay@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8319,14 +8514,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-baidu@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-baidu@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app': 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app': 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -8348,12 +8543,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-compiler@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-compiler@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
@@ -8368,11 +8563,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-jd@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-jd@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8385,13 +8580,13 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-kuaishou@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-kuaishou@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -8407,12 +8602,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-lark@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-lark@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-toutiao': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-toutiao': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8426,10 +8621,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-qq@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-qq@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8443,11 +8638,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-toutiao@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-toutiao@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8461,11 +8656,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-dom': 3.4.21
@@ -8486,10 +8681,10 @@ snapshots:
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
 
-  '@dcloudio/uni-mp-weixin@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-weixin@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8510,11 +8705,11 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-xhs@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-xhs@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8532,9 +8727,9 @@ snapshots:
       parse-css-font: 4.0.0
       postcss: 8.5.6
 
-  '@dcloudio/uni-push@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-push@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -8544,10 +8739,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-quickapp-webview@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-quickapp-webview@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8566,9 +8761,9 @@ snapshots:
 
   '@dcloudio/uni-stacktracey@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-stat@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-stat@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       debug: 4.4.3
     transitivePeerDependencies:
@@ -8580,17 +8775,17 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
-      '@vitejs/plugin-legacy': 5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
+      '@vitejs/plugin-legacy': 5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -8607,7 +8802,7 @@ snapshots:
       picocolors: 1.1.1
       terser: 5.44.0
       unplugin-auto-import: 19.1.0(@vueuse/core@12.8.2(typescript@5.9.2))
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -8681,7 +8876,7 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.9':
+  '@esbuild/aix-ppc64@0.25.10':
     optional: true
 
   '@esbuild/android-arm64@0.20.2':
@@ -8690,7 +8885,7 @@ snapshots:
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
-  '@esbuild/android-arm64@0.25.9':
+  '@esbuild/android-arm64@0.25.10':
     optional: true
 
   '@esbuild/android-arm@0.20.2':
@@ -8699,7 +8894,7 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
-  '@esbuild/android-arm@0.25.9':
+  '@esbuild/android-arm@0.25.10':
     optional: true
 
   '@esbuild/android-x64@0.20.2':
@@ -8708,7 +8903,7 @@ snapshots:
   '@esbuild/android-x64@0.21.5':
     optional: true
 
-  '@esbuild/android-x64@0.25.9':
+  '@esbuild/android-x64@0.25.10':
     optional: true
 
   '@esbuild/darwin-arm64@0.20.2':
@@ -8717,7 +8912,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.9':
+  '@esbuild/darwin-arm64@0.25.10':
     optional: true
 
   '@esbuild/darwin-x64@0.20.2':
@@ -8726,7 +8921,7 @@ snapshots:
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.9':
+  '@esbuild/darwin-x64@0.25.10':
     optional: true
 
   '@esbuild/freebsd-arm64@0.20.2':
@@ -8735,7 +8930,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.9':
+  '@esbuild/freebsd-arm64@0.25.10':
     optional: true
 
   '@esbuild/freebsd-x64@0.20.2':
@@ -8744,7 +8939,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.9':
+  '@esbuild/freebsd-x64@0.25.10':
     optional: true
 
   '@esbuild/linux-arm64@0.20.2':
@@ -8753,7 +8948,7 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.9':
+  '@esbuild/linux-arm64@0.25.10':
     optional: true
 
   '@esbuild/linux-arm@0.20.2':
@@ -8762,7 +8957,7 @@ snapshots:
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
-  '@esbuild/linux-arm@0.25.9':
+  '@esbuild/linux-arm@0.25.10':
     optional: true
 
   '@esbuild/linux-ia32@0.20.2':
@@ -8771,7 +8966,7 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.9':
+  '@esbuild/linux-ia32@0.25.10':
     optional: true
 
   '@esbuild/linux-loong64@0.20.2':
@@ -8780,7 +8975,7 @@ snapshots:
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.9':
+  '@esbuild/linux-loong64@0.25.10':
     optional: true
 
   '@esbuild/linux-mips64el@0.20.2':
@@ -8789,7 +8984,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.9':
+  '@esbuild/linux-mips64el@0.25.10':
     optional: true
 
   '@esbuild/linux-ppc64@0.20.2':
@@ -8798,7 +8993,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.9':
+  '@esbuild/linux-ppc64@0.25.10':
     optional: true
 
   '@esbuild/linux-riscv64@0.20.2':
@@ -8807,7 +9002,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.9':
+  '@esbuild/linux-riscv64@0.25.10':
     optional: true
 
   '@esbuild/linux-s390x@0.20.2':
@@ -8816,7 +9011,7 @@ snapshots:
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.9':
+  '@esbuild/linux-s390x@0.25.10':
     optional: true
 
   '@esbuild/linux-x64@0.20.2':
@@ -8825,10 +9020,10 @@ snapshots:
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
-  '@esbuild/linux-x64@0.25.9':
+  '@esbuild/linux-x64@0.25.10':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.9':
+  '@esbuild/netbsd-arm64@0.25.10':
     optional: true
 
   '@esbuild/netbsd-x64@0.20.2':
@@ -8837,10 +9032,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.9':
+  '@esbuild/netbsd-x64@0.25.10':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.9':
+  '@esbuild/openbsd-arm64@0.25.10':
     optional: true
 
   '@esbuild/openbsd-x64@0.20.2':
@@ -8849,10 +9044,10 @@ snapshots:
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.9':
+  '@esbuild/openbsd-x64@0.25.10':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.9':
+  '@esbuild/openharmony-arm64@0.25.10':
     optional: true
 
   '@esbuild/sunos-x64@0.20.2':
@@ -8861,7 +9056,7 @@ snapshots:
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.9':
+  '@esbuild/sunos-x64@0.25.10':
     optional: true
 
   '@esbuild/win32-arm64@0.20.2':
@@ -8870,7 +9065,7 @@ snapshots:
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.9':
+  '@esbuild/win32-arm64@0.25.10':
     optional: true
 
   '@esbuild/win32-ia32@0.20.2':
@@ -8879,7 +9074,7 @@ snapshots:
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.9':
+  '@esbuild/win32-ia32@0.25.10':
     optional: true
 
   '@esbuild/win32-x64@0.20.2':
@@ -8888,25 +9083,25 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@esbuild/win32-x64@0.25.9':
+  '@esbuild/win32-x64@0.25.10':
     optional: true
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.35.0(jiti@2.5.1))':
+  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.36.0(jiti@2.5.1))':
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       ignore: 5.3.2
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.35.0(jiti@2.5.1))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0(jiti@2.5.1))':
     dependencies:
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.3.2(eslint@9.35.0(jiti@2.5.1))':
+  '@eslint/compat@1.3.2(eslint@9.36.0(jiti@2.5.1))':
     optionalDependencies:
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
 
   '@eslint/config-array@0.21.0':
     dependencies:
@@ -8936,7 +9131,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.35.0': {}
+  '@eslint/js@9.36.0': {}
 
   '@eslint/markdown@7.2.0':
     dependencies:
@@ -9004,7 +9199,7 @@ snapshots:
   '@iconify/utils@3.0.2':
     dependencies:
       '@antfu/install-pkg': 1.1.0
-      '@antfu/utils': 9.2.0
+      '@antfu/utils': 9.2.1
       '@iconify/types': 2.0.0
       debug: 4.4.3
       globals: 15.15.0
@@ -9077,7 +9272,7 @@ snapshots:
   '@jest/console@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -9090,7 +9285,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -9124,14 +9319,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       jest-mock: 27.5.1
 
   '@jest/fake-timers@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -9149,7 +9344,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -9218,7 +9413,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -9525,9 +9720,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@keyv/bigmap@1.0.0':
+  '@keyv/bigmap@1.0.2':
     dependencies:
-      hookified: 1.12.0
+      hookified: 1.12.1
 
   '@keyv/serialize@1.1.1': {}
 
@@ -9559,54 +9754,54 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@oxc-parser/binding-android-arm64@0.89.0':
+  '@oxc-parser/binding-android-arm64@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.89.0':
+  '@oxc-parser/binding-darwin-arm64@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.89.0':
+  '@oxc-parser/binding-darwin-x64@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.89.0':
+  '@oxc-parser/binding-freebsd-x64@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.89.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.89.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.89.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.89.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.89.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.89.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-gnu@0.89.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-musl@0.89.0':
+  '@oxc-parser/binding-linux-x64-musl@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.89.0':
+  '@oxc-parser/binding-wasm32-wasi@0.90.0':
     dependencies:
       '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.89.0':
+  '@oxc-parser/binding-win32-arm64-msvc@0.90.0':
     optional: true
 
-  '@oxc-parser/binding-win32-x64-msvc@0.89.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.90.0':
     optional: true
 
-  '@oxc-project/types@0.89.0': {}
+  '@oxc-project/types@0.90.0': {}
 
   '@pkgr/core@0.2.9': {}
 
@@ -9616,13 +9811,13 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rollup/plugin-alias@5.1.1(rollup@4.50.2)':
+  '@rollup/plugin-alias@5.1.1(rollup@4.52.0)':
     optionalDependencies:
-      rollup: 4.50.2
+      rollup: 4.52.0
 
-  '@rollup/plugin-commonjs@28.0.6(rollup@4.50.2)':
+  '@rollup/plugin-commonjs@28.0.6(rollup@4.52.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9630,100 +9825,103 @@ snapshots:
       magic-string: 0.30.19
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.50.2
+      rollup: 4.52.0
 
-  '@rollup/plugin-json@6.1.0(rollup@4.50.2)':
+  '@rollup/plugin-json@6.1.0(rollup@4.52.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
     optionalDependencies:
-      rollup: 4.50.2
+      rollup: 4.52.0
 
-  '@rollup/plugin-node-resolve@16.0.1(rollup@4.50.2)':
+  '@rollup/plugin-node-resolve@16.0.1(rollup@4.52.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.50.2
+      rollup: 4.52.0
 
-  '@rollup/plugin-replace@6.0.2(rollup@4.50.2)':
+  '@rollup/plugin-replace@6.0.2(rollup@4.52.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       magic-string: 0.30.19
     optionalDependencies:
-      rollup: 4.50.2
+      rollup: 4.52.0
 
-  '@rollup/pluginutils@5.3.0(rollup@4.50.2)':
+  '@rollup/pluginutils@5.3.0(rollup@4.52.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.50.2
+      rollup: 4.52.0
 
-  '@rollup/rollup-android-arm-eabi@4.50.2':
+  '@rollup/rollup-android-arm-eabi@4.52.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.50.2':
+  '@rollup/rollup-android-arm64@4.52.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.50.2':
+  '@rollup/rollup-darwin-arm64@4.52.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.50.2':
+  '@rollup/rollup-darwin-x64@4.52.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.50.2':
+  '@rollup/rollup-freebsd-arm64@4.52.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.50.2':
+  '@rollup/rollup-freebsd-x64@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.50.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.50.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.50.2':
+  '@rollup/rollup-linux-arm64-gnu@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.50.2':
+  '@rollup/rollup-linux-arm64-musl@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.50.2':
+  '@rollup/rollup-linux-loong64-gnu@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.50.2':
+  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.50.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.50.2':
+  '@rollup/rollup-linux-riscv64-musl@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.50.2':
+  '@rollup/rollup-linux-s390x-gnu@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.50.2':
+  '@rollup/rollup-linux-x64-gnu@4.52.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.50.2':
+  '@rollup/rollup-linux-x64-musl@4.52.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.50.2':
+  '@rollup/rollup-openharmony-arm64@4.52.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.50.2':
+  '@rollup/rollup-win32-arm64-msvc@4.52.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.50.2':
+  '@rollup/rollup-win32-ia32-msvc@4.52.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.50.2':
+  '@rollup/rollup-win32-x64-gnu@4.52.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.0':
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -9778,11 +9976,11 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 1.8.6
 
-  '@stylistic/eslint-plugin@5.3.1(eslint@9.35.0(jiti@2.5.1))':
+  '@stylistic/eslint-plugin@5.4.0(eslint@9.36.0(jiti@2.5.1))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       '@typescript-eslint/types': 8.44.0
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -9831,11 +10029,11 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
 
   '@types/hast@3.0.4':
     dependencies:
@@ -9855,7 +10053,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
 
   '@types/linkify-it@5.0.0': {}
 
@@ -9878,7 +10076,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.5.1':
+  '@types/node@24.5.2':
     dependencies:
       undici-types: 7.12.0
 
@@ -9898,15 +10096,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.44.0
-      '@typescript-eslint/type-utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.44.0
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -9915,14 +10113,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.44.0
       '@typescript-eslint/types': 8.44.0
       '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.44.0
       debug: 4.4.3
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -9945,13 +10143,13 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.44.0
       '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
       debug: 4.4.3
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -9975,13 +10173,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       '@typescript-eslint/scope-manager': 8.44.0
       '@typescript-eslint/types': 8.44.0
       '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.8.3)
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -9993,9 +10191,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@uni-helper/plugin-uni@0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
+  '@uni-helper/plugin-uni@0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
     dependencies:
-      '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
   '@uni-helper/uni-app-types@1.0.0-alpha.6(typescript@5.8.3)(vue@3.4.38(typescript@5.8.3))':
     dependencies:
@@ -10006,21 +10204,21 @@ snapshots:
     dependencies:
       std-env: 3.9.0
 
-  '@uni-helper/unocss-preset-uni@0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
+  '@uni-helper/unocss-preset-uni@0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
     dependencies:
       '@uni-helper/uni-env': 0.1.8
       '@unocss/preset-legacy-compat': 66.5.1
       '@unocss/rule-utils': 66.5.1
-      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      unocss-applet: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      unocss-applet: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
     optionalDependencies:
       '@unocss/preset-mini': 66.5.1
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
-  '@uni-helper/vite-plugin-uni-components@0.2.0(rollup@4.50.2)':
+  '@uni-helper/vite-plugin-uni-components@0.2.1(rollup@4.52.0)':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       chokidar: 3.6.0
       debug: 4.4.3
       fast-glob: 3.3.3
@@ -10032,14 +10230,14 @@ snapshots:
       - rollup
       - supports-color
 
-  '@uni-helper/vite-plugin-uni-manifest@0.2.8(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))':
+  '@uni-helper/vite-plugin-uni-manifest@0.2.8(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       c12: 2.0.4
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - magicast
 
-  '@uni-helper/vite-plugin-uni-pages@0.3.14(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))':
+  '@uni-helper/vite-plugin-uni-pages@0.3.15(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/types': 7.28.4
@@ -10058,7 +10256,7 @@ snapshots:
       magic-string: 0.30.19
       typescript: 5.9.2
       unconfig: 7.3.3
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
       yaml: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -10079,13 +10277,13 @@ snapshots:
       '@unocss/core': 66.5.1
       magic-string: 0.30.19
 
-  '@unocss/astro@66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@unocss/astro@66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@unocss/core': 66.0.0
       '@unocss/reset': 66.0.0
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - vue
 
@@ -10243,7 +10441,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.0.0
 
-  '@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.0.0
@@ -10253,11 +10451,11 @@ snapshots:
       magic-string: 0.30.19
       tinyglobby: 0.2.15
       unplugin-utils: 0.2.5
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - vue
 
-  '@vitejs/plugin-legacy@5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))':
+  '@vitejs/plugin-legacy@5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/preset-env': 7.28.3(@babel/core@7.28.4)
@@ -10268,38 +10466,38 @@ snapshots:
       regenerator-runtime: 0.14.1
       systemjs: 6.15.1
       terser: 5.44.0
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
-  '@vitest/eslint-plugin@1.3.12(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0))':
+  '@vitest/eslint-plugin@1.3.12(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.44.0
-      '@typescript-eslint/utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      eslint: 9.35.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint: 9.36.0(jiti@2.5.1)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10311,13 +10509,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@24.5.1)(terser@5.44.0))':
+  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@24.5.2)(terser@5.44.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10337,7 +10535,7 @@ snapshots:
 
   '@vitest/spy@3.2.4':
     dependencies:
-      tinyspy: 4.0.3
+      tinyspy: 4.0.4
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -10584,44 +10782,44 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@xiaohe01/eslint-config@2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0))':
+  '@xiaohe01/eslint-config@2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
-      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.36.0(jiti@2.5.1))
       '@eslint/markdown': 7.2.0
-      '@stylistic/eslint-plugin': 5.3.1(eslint@9.35.0(jiti@2.5.1))
-      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      '@vitest/eslint-plugin': 1.3.12(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0))
+      '@stylistic/eslint-plugin': 5.4.0(eslint@9.36.0(jiti@2.5.1))
+      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
+      '@vitest/eslint-plugin': 1.3.12(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0))
       ansis: 4.1.0
       cac: 6.7.14
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-config-flat-gitignore: 2.1.0(eslint@9.35.0(jiti@2.5.1))
-      eslint-flat-config-utils: 2.1.1
-      eslint-merge-processors: 2.0.0(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-antfu: 3.1.1(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-command: 3.3.1(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-import-lite: 0.3.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      eslint-plugin-jsdoc: 54.7.0(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-jsonc: 2.20.1(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-n: 17.23.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint: 9.36.0(jiti@2.5.1)
+      eslint-config-flat-gitignore: 2.1.0(eslint@9.36.0(jiti@2.5.1))
+      eslint-flat-config-utils: 2.1.4
+      eslint-merge-processors: 2.0.0(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-antfu: 3.1.1(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-command: 3.3.1(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-import-lite: 0.3.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint-plugin-jsdoc: 54.7.0(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-jsonc: 2.20.1(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-n: 17.23.1(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 4.15.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      eslint-plugin-pnpm: 1.1.1(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-regexp: 2.10.0(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-toml: 0.12.0(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-unicorn: 61.0.2(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1)))
-      eslint-plugin-yml: 1.18.0(eslint@9.35.0(jiti@2.5.1))
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-perfectionist: 4.15.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint-plugin-pnpm: 1.1.1(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-regexp: 2.10.0(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-toml: 0.12.0(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-unicorn: 61.0.2(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1)))
+      eslint-plugin-yml: 1.18.0(eslint@9.36.0(jiti@2.5.1))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1))
       globals: 16.4.0
-      jsonc-eslint-parser: 2.4.0
+      jsonc-eslint-parser: 2.4.1
       local-pkg: 1.1.2
       parse-gitignore: 2.0.0
       toml-eslint-parser: 0.10.0
-      vue-eslint-parser: 10.2.0(eslint@9.35.0(jiti@2.5.1))
+      vue-eslint-parser: 10.2.0(eslint@9.36.0(jiti@2.5.1))
       yaml-eslint-parser: 1.3.0
     transitivePeerDependencies:
       - '@eslint/json'
@@ -10865,7 +11063,7 @@ snapshots:
 
   base64url@3.0.1: {}
 
-  baseline-browser-mapping@2.8.4: {}
+  baseline-browser-mapping@2.8.6: {}
 
   binary-extensions@2.3.0: {}
 
@@ -10914,9 +11112,9 @@ snapshots:
 
   browserslist@4.26.2:
     dependencies:
-      baseline-browser-mapping: 2.8.4
+      baseline-browser-mapping: 2.8.6
       caniuse-lite: 1.0.30001743
-      electron-to-chromium: 1.5.219
+      electron-to-chromium: 1.5.222
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
@@ -10996,8 +11194,8 @@ snapshots:
       '@cacheable/memoize': 2.0.1
       '@cacheable/memory': 2.0.1
       '@cacheable/utils': 2.0.1
-      hookified: 1.12.0
-      keyv: 5.5.1
+      hookified: 1.12.1
+      keyv: 5.5.2
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -11205,7 +11403,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-declaration-sorter@7.2.0(postcss@8.5.6):
+  css-declaration-sorter@7.3.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
 
@@ -11248,7 +11446,7 @@ snapshots:
   cssnano-preset-default@7.0.9(postcss@8.5.6):
     dependencies:
       browserslist: 4.26.2
-      css-declaration-sorter: 7.2.0(postcss@8.5.6)
+      css-declaration-sorter: 7.3.0(postcss@8.5.6)
       cssnano-utils: 5.0.1(postcss@8.5.6)
       postcss: 8.5.6
       postcss-calc: 10.1.1(postcss@8.5.6)
@@ -11419,7 +11617,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.219: {}
+  electron-to-chromium@1.5.222: {}
 
   emittery@0.8.1: {}
 
@@ -11523,34 +11721,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
-  esbuild@0.25.9:
+  esbuild@0.25.10:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.9
-      '@esbuild/android-arm': 0.25.9
-      '@esbuild/android-arm64': 0.25.9
-      '@esbuild/android-x64': 0.25.9
-      '@esbuild/darwin-arm64': 0.25.9
-      '@esbuild/darwin-x64': 0.25.9
-      '@esbuild/freebsd-arm64': 0.25.9
-      '@esbuild/freebsd-x64': 0.25.9
-      '@esbuild/linux-arm': 0.25.9
-      '@esbuild/linux-arm64': 0.25.9
-      '@esbuild/linux-ia32': 0.25.9
-      '@esbuild/linux-loong64': 0.25.9
-      '@esbuild/linux-mips64el': 0.25.9
-      '@esbuild/linux-ppc64': 0.25.9
-      '@esbuild/linux-riscv64': 0.25.9
-      '@esbuild/linux-s390x': 0.25.9
-      '@esbuild/linux-x64': 0.25.9
-      '@esbuild/netbsd-arm64': 0.25.9
-      '@esbuild/netbsd-x64': 0.25.9
-      '@esbuild/openbsd-arm64': 0.25.9
-      '@esbuild/openbsd-x64': 0.25.9
-      '@esbuild/openharmony-arm64': 0.25.9
-      '@esbuild/sunos-x64': 0.25.9
-      '@esbuild/win32-arm64': 0.25.9
-      '@esbuild/win32-ia32': 0.25.9
-      '@esbuild/win32-x64': 0.25.9
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
 
   escalade@3.2.0: {}
 
@@ -11572,67 +11770,67 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.35.0(jiti@2.5.1)):
+  eslint-compat-utils@0.5.1(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       semver: 7.7.2
 
-  eslint-compat-utils@0.6.5(eslint@9.35.0(jiti@2.5.1)):
+  eslint-compat-utils@0.6.5(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       semver: 7.7.2
 
-  eslint-config-flat-gitignore@2.1.0(eslint@9.35.0(jiti@2.5.1)):
+  eslint-config-flat-gitignore@2.1.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      '@eslint/compat': 1.3.2(eslint@9.35.0(jiti@2.5.1))
-      eslint: 9.35.0(jiti@2.5.1)
+      '@eslint/compat': 1.3.2(eslint@9.36.0(jiti@2.5.1))
+      eslint: 9.36.0(jiti@2.5.1)
 
-  eslint-flat-config-utils@2.1.1:
+  eslint-flat-config-utils@2.1.4:
     dependencies:
       pathe: 2.0.3
 
-  eslint-json-compat-utils@0.2.1(eslint@9.35.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0):
+  eslint-json-compat-utils@0.2.1(eslint@9.36.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.1):
     dependencies:
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       esquery: 1.6.0
-      jsonc-eslint-parser: 2.4.0
+      jsonc-eslint-parser: 2.4.1
 
-  eslint-merge-processors@2.0.0(eslint@9.35.0(jiti@2.5.1)):
+  eslint-merge-processors@2.0.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
 
-  eslint-plugin-antfu@3.1.1(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-antfu@3.1.1(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
 
-  eslint-plugin-command@3.3.1(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-command@3.3.1(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       '@es-joy/jsdoccomment': 0.50.2
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
 
-  eslint-plugin-es-x@7.8.0(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-es-x@7.8.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-compat-utils: 0.5.1(eslint@9.35.0(jiti@2.5.1))
+      eslint: 9.36.0(jiti@2.5.1)
+      eslint-compat-utils: 0.5.1(eslint@9.36.0(jiti@2.5.1))
 
-  eslint-plugin-import-lite@0.3.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
+  eslint-plugin-import-lite@0.3.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       '@typescript-eslint/types': 8.44.0
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
     optionalDependencies:
       typescript: 5.8.3
 
-  eslint-plugin-jsdoc@54.7.0(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-jsdoc@54.7.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       '@es-joy/jsdoccomment': 0.56.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       espree: 10.4.0
       esquery: 1.6.0
       parse-imports-exports: 0.2.4
@@ -11641,26 +11839,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsonc@2.20.1(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-jsonc@2.20.1(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-compat-utils: 0.6.5(eslint@9.35.0(jiti@2.5.1))
-      eslint-json-compat-utils: 0.2.1(eslint@9.35.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
+      eslint: 9.36.0(jiti@2.5.1)
+      eslint-compat-utils: 0.6.5(eslint@9.36.0(jiti@2.5.1))
+      eslint-json-compat-utils: 0.2.1(eslint@9.36.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.1)
       espree: 10.4.0
       graphemer: 1.4.0
-      jsonc-eslint-parser: 2.4.0
+      jsonc-eslint-parser: 2.4.1
       natural-compare: 1.4.0
       synckit: 0.11.11
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@17.23.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
+  eslint-plugin-n@17.23.1(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       enhanced-resolve: 5.18.3
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-plugin-es-x: 7.8.0(eslint@9.35.0(jiti@2.5.1))
+      eslint: 9.36.0(jiti@2.5.1)
+      eslint-plugin-es-x: 7.8.0(eslint@9.36.0(jiti@2.5.1))
       get-tsconfig: 4.10.1
       globals: 15.15.0
       globrex: 0.1.2
@@ -11672,57 +11870,57 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-perfectionist@4.15.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
+  eslint-plugin-perfectionist@4.15.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/types': 8.44.0
-      '@typescript-eslint/utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      eslint: 9.35.0(jiti@2.5.1)
+      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint: 9.36.0(jiti@2.5.1)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-pnpm@1.1.1(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-pnpm@1.1.1(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       empathic: 2.0.0
-      eslint: 9.35.0(jiti@2.5.1)
-      jsonc-eslint-parser: 2.4.0
+      eslint: 9.36.0(jiti@2.5.1)
+      jsonc-eslint-parser: 2.4.1
       pathe: 2.0.3
       pnpm-workspace-yaml: 1.1.1
       tinyglobby: 0.2.15
       yaml-eslint-parser: 1.3.0
 
-  eslint-plugin-regexp@2.10.0(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-regexp@2.10.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
       comment-parser: 1.4.1
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       jsdoc-type-pratt-parser: 4.8.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-toml@0.12.0(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-toml@0.12.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       debug: 4.4.3
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-compat-utils: 0.6.5(eslint@9.35.0(jiti@2.5.1))
+      eslint: 9.36.0(jiti@2.5.1)
+      eslint-compat-utils: 0.6.5(eslint@9.36.0(jiti@2.5.1))
       lodash: 4.17.21
       toml-eslint-parser: 0.10.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@61.0.2(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-unicorn@61.0.2(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       '@eslint/plugin-kit': 0.3.5
       change-case: 5.4.4
       ci-info: 4.3.0
       clean-regexp: 1.0.0
       core-js-compat: 3.45.1
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       esquery: 1.6.0
       find-up-simple: 1.0.1
       globals: 16.4.0
@@ -11735,40 +11933,40 @@ snapshots:
       semver: 7.7.2
       strip-indent: 4.1.0
 
-  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
 
-  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1))):
+  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
-      eslint: 9.35.0(jiti@2.5.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
+      eslint: 9.36.0(jiti@2.5.1)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.7.2
-      vue-eslint-parser: 10.2.0(eslint@9.35.0(jiti@2.5.1))
+      vue-eslint-parser: 10.2.0(eslint@9.36.0(jiti@2.5.1))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
 
-  eslint-plugin-yml@1.18.0(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-yml@1.18.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint: 9.35.0(jiti@2.5.1)
-      eslint-compat-utils: 0.6.5(eslint@9.35.0(jiti@2.5.1))
+      eslint: 9.36.0(jiti@2.5.1)
+      eslint-compat-utils: 0.6.5(eslint@9.36.0(jiti@2.5.1))
       natural-compare: 1.4.0
       yaml-eslint-parser: 1.3.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1)):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       '@vue/compiler-sfc': 3.5.21
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -11779,15 +11977,15 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.35.0(jiti@2.5.1):
+  eslint@9.36.0(jiti@2.5.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
       '@eslint/config-helpers': 0.3.1
       '@eslint/core': 0.15.2
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.35.0
+      '@eslint/js': 9.36.0
       '@eslint/plugin-kit': 0.3.5
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
@@ -12033,7 +12231,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.19
       mlly: 1.8.0
-      rollup: 4.50.2
+      rollup: 4.52.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -12044,7 +12242,7 @@ snapshots:
     dependencies:
       cacheable: 2.0.1
       flatted: 3.3.3
-      hookified: 1.12.0
+      hookified: 1.12.1
 
   flatted@3.3.3: {}
 
@@ -12277,7 +12475,7 @@ snapshots:
 
   hookable@5.5.3: {}
 
-  hookified@1.12.0: {}
+  hookified@1.12.1: {}
 
   html-encoding-sniffer@2.0.1:
     dependencies:
@@ -12484,7 +12682,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -12580,7 +12778,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -12595,7 +12793,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -12605,7 +12803,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12624,7 +12822,7 @@ snapshots:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -12667,7 +12865,7 @@ snapshots:
   jest-mock@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
 
   jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     optionalDependencies:
@@ -12703,7 +12901,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -12754,7 +12952,7 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
@@ -12787,7 +12985,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12806,7 +13004,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -12814,7 +13012,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -12916,7 +13114,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonc-eslint-parser@2.4.0:
+  jsonc-eslint-parser@2.4.1:
     dependencies:
       acorn: 8.15.0
       eslint-visitor-keys: 3.4.3
@@ -12935,7 +13133,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  keyv@5.5.1:
+  keyv@5.5.2:
     dependencies:
       '@keyv/serialize': 1.1.1
 
@@ -13525,7 +13723,7 @@ snapshots:
       citty: 0.1.6
       cssnano: 7.1.1(postcss@8.5.6)
       defu: 6.1.4
-      esbuild: 0.25.9
+      esbuild: 0.25.10
       jiti: 1.21.7
       mlly: 1.8.0
       pathe: 2.0.3
@@ -13662,25 +13860,25 @@ snapshots:
     dependencies:
       lcid: 3.1.1
 
-  oxc-parser@0.89.0:
+  oxc-parser@0.90.0:
     dependencies:
-      '@oxc-project/types': 0.89.0
+      '@oxc-project/types': 0.90.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm64': 0.89.0
-      '@oxc-parser/binding-darwin-arm64': 0.89.0
-      '@oxc-parser/binding-darwin-x64': 0.89.0
-      '@oxc-parser/binding-freebsd-x64': 0.89.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.89.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.89.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.89.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.89.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.89.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.89.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.89.0
-      '@oxc-parser/binding-linux-x64-musl': 0.89.0
-      '@oxc-parser/binding-wasm32-wasi': 0.89.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.89.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.89.0
+      '@oxc-parser/binding-android-arm64': 0.90.0
+      '@oxc-parser/binding-darwin-arm64': 0.90.0
+      '@oxc-parser/binding-darwin-x64': 0.90.0
+      '@oxc-parser/binding-freebsd-x64': 0.90.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.90.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.90.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.90.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.90.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.90.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.90.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.90.0
+      '@oxc-parser/binding-linux-x64-musl': 0.90.0
+      '@oxc-parser/binding-wasm32-wasi': 0.90.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.90.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.90.0
 
   p-limit@2.3.0:
     dependencies:
@@ -14118,7 +14316,7 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
-  pretty-bytes@7.0.1: {}
+  pretty-bytes@7.1.0: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -14315,39 +14513,40 @@ snapshots:
       glob: 11.0.3
       package-json-from-dist: 1.0.1
 
-  rollup-plugin-dts@6.2.3(rollup@4.50.2)(typescript@5.8.3):
+  rollup-plugin-dts@6.2.3(rollup@4.52.0)(typescript@5.8.3):
     dependencies:
       magic-string: 0.30.19
-      rollup: 4.50.2
+      rollup: 4.52.0
       typescript: 5.8.3
     optionalDependencies:
       '@babel/code-frame': 7.27.1
 
-  rollup@4.50.2:
+  rollup@4.52.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.50.2
-      '@rollup/rollup-android-arm64': 4.50.2
-      '@rollup/rollup-darwin-arm64': 4.50.2
-      '@rollup/rollup-darwin-x64': 4.50.2
-      '@rollup/rollup-freebsd-arm64': 4.50.2
-      '@rollup/rollup-freebsd-x64': 4.50.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.50.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.50.2
-      '@rollup/rollup-linux-arm64-gnu': 4.50.2
-      '@rollup/rollup-linux-arm64-musl': 4.50.2
-      '@rollup/rollup-linux-loong64-gnu': 4.50.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.50.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.50.2
-      '@rollup/rollup-linux-riscv64-musl': 4.50.2
-      '@rollup/rollup-linux-s390x-gnu': 4.50.2
-      '@rollup/rollup-linux-x64-gnu': 4.50.2
-      '@rollup/rollup-linux-x64-musl': 4.50.2
-      '@rollup/rollup-openharmony-arm64': 4.50.2
-      '@rollup/rollup-win32-arm64-msvc': 4.50.2
-      '@rollup/rollup-win32-ia32-msvc': 4.50.2
-      '@rollup/rollup-win32-x64-msvc': 4.50.2
+      '@rollup/rollup-android-arm-eabi': 4.52.0
+      '@rollup/rollup-android-arm64': 4.52.0
+      '@rollup/rollup-darwin-arm64': 4.52.0
+      '@rollup/rollup-darwin-x64': 4.52.0
+      '@rollup/rollup-freebsd-arm64': 4.52.0
+      '@rollup/rollup-freebsd-x64': 4.52.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
+      '@rollup/rollup-linux-arm64-gnu': 4.52.0
+      '@rollup/rollup-linux-arm64-musl': 4.52.0
+      '@rollup/rollup-linux-loong64-gnu': 4.52.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
+      '@rollup/rollup-linux-riscv64-musl': 4.52.0
+      '@rollup/rollup-linux-s390x-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-gnu': 4.52.0
+      '@rollup/rollup-linux-x64-musl': 4.52.0
+      '@rollup/rollup-openharmony-arm64': 4.52.0
+      '@rollup/rollup-win32-arm64-msvc': 4.52.0
+      '@rollup/rollup-win32-ia32-msvc': 4.52.0
+      '@rollup/rollup-win32-x64-gnu': 4.52.0
+      '@rollup/rollup-win32-x64-msvc': 4.52.0
       fsevents: 2.3.3
 
   run-applescript@7.1.0: {}
@@ -14770,7 +14969,7 @@ snapshots:
 
   tinyrainbow@2.0.0: {}
 
-  tinyspy@4.0.3: {}
+  tinyspy@4.0.4: {}
 
   tmpl@1.0.5: {}
 
@@ -14819,7 +15018,7 @@ snapshots:
 
   tsx@4.20.5:
     dependencies:
-      esbuild: 0.25.9
+      esbuild: 0.25.10
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
@@ -14851,16 +15050,16 @@ snapshots:
 
   unbuild@3.5.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
     dependencies:
-      '@rollup/plugin-alias': 5.1.1(rollup@4.50.2)
-      '@rollup/plugin-commonjs': 28.0.6(rollup@4.50.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.50.2)
-      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.50.2)
-      '@rollup/plugin-replace': 6.0.2(rollup@4.50.2)
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.52.0)
+      '@rollup/plugin-commonjs': 28.0.6(rollup@4.52.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.52.0)
+      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.52.0)
+      '@rollup/plugin-replace': 6.0.2(rollup@4.52.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
-      esbuild: 0.25.9
+      esbuild: 0.25.10
       fix-dts-default-cjs-exports: 1.0.1
       hookable: 5.5.3
       jiti: 2.5.1
@@ -14870,8 +15069,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       pretty-bytes: 6.1.1
-      rollup: 4.50.2
-      rollup-plugin-dts: 6.2.3(rollup@4.50.2)(typescript@5.8.3)
+      rollup: 4.52.0
+      rollup-plugin-dts: 6.2.3(rollup@4.52.0)(typescript@5.8.3)
       scule: 1.3.0
       tinyglobby: 0.2.15
       untyped: 2.0.0
@@ -14940,7 +15139,7 @@ snapshots:
       unplugin: 2.3.10
       unplugin-utils: 0.2.5
 
-  unimport@5.2.0:
+  unimport@5.3.0:
     dependencies:
       acorn: 8.15.0
       escape-string-regexp: 5.0.0
@@ -14955,7 +15154,7 @@ snapshots:
       strip-literal: 3.0.0
       tinyglobby: 0.2.15
       unplugin: 2.3.10
-      unplugin-utils: 0.2.5
+      unplugin-utils: 0.3.0
 
   unist-util-is@6.0.0:
     dependencies:
@@ -14990,16 +15189,16 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))):
+  unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))):
     dependencies:
       '@unocss-applet/preset-applet': 0.11.0
       '@unocss-applet/preset-rem-rpx': 0.11.0
       '@unocss-applet/transformer-attributify': 0.11.0
-      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
-  unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)):
+  unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)):
     dependencies:
-      '@unocss/astro': 66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/astro': 66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@unocss/cli': 66.0.0
       '@unocss/core': 66.0.0
       '@unocss/postcss': 66.0.0(postcss@8.5.6)
@@ -15016,9 +15215,9 @@ snapshots:
       '@unocss/transformer-compile-class': 66.0.0
       '@unocss/transformer-directives': 66.0.0
       '@unocss/transformer-variant-group': 66.0.0
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -15042,7 +15241,7 @@ snapshots:
       local-pkg: 1.1.2
       magic-string: 0.30.19
       picomatch: 4.0.3
-      unimport: 5.2.0
+      unimport: 5.3.0
       unplugin: 2.3.10
       unplugin-utils: 0.3.0
     optionalDependencies:
@@ -15116,13 +15315,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.5.1)(terser@5.44.0):
+  vite-node@3.2.4(@types/node@24.5.2)(terser@5.44.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15134,10 +15333,10 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-inspect@0.8.9(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)):
+  vite-plugin-inspect@0.8.9(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
       debug: 4.4.3
       error-stack-parser-es: 0.1.5
       fs-extra: 11.3.2
@@ -15145,31 +15344,31 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.2
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
   vite-plugin-uni-polyfill@0.1.0: {}
 
-  vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0):
+  vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
-      rollup: 4.50.2
+      rollup: 4.52.0
     optionalDependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       fsevents: 2.3.3
       sass: 1.78.0
       terser: 5.44.0
 
-  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)):
+  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)):
     dependencies:
       '@iconify-json/logos': 1.2.9
       '@iconify-json/vscode-icons': 1.2.30
       '@iconify/utils': 3.0.2
       markdown-it: 14.1.0
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15182,7 +15381,7 @@ snapshots:
       minimatch: 10.0.3
       path-to-regexp: 8.3.0
       picocolors: 1.1.1
-      pretty-bytes: 7.0.1
+      pretty-bytes: 7.1.0
       remark: 15.0.1
       remark-frontmatter: 5.0.0
       tokenx: 1.1.0
@@ -15191,7 +15390,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.6.4(@algolia/client-search@5.37.0)(@types/node@24.5.1)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2):
+  vitepress@1.6.4(@algolia/client-search@5.37.0)(@types/node@24.5.2)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.37.0)(search-insights@2.17.3)
@@ -15200,7 +15399,7 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.21
       '@vueuse/core': 12.8.2(typescript@5.9.2)
@@ -15209,7 +15408,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
     optionalDependencies:
       postcss: 8.5.6
@@ -15240,11 +15439,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jsdom@16.7.0)(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@24.5.1)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@24.5.2)(terser@5.44.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -15262,12 +15461,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
-      vite-node: 3.2.4(@types/node@24.5.1)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite-node: 3.2.4(@types/node@24.5.2)(terser@5.44.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       jsdom: 16.7.0
     transitivePeerDependencies:
       - less
@@ -15286,10 +15485,10 @@ snapshots:
     dependencies:
       vue: 3.4.38(typescript@5.9.2)
 
-  vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1)):
+  vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       debug: 4.4.3
-      eslint: 9.35.0(jiti@2.5.1)
+      eslint: 9.36.0(jiti@2.5.1)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,17 +13,20 @@ catalogs:
       specifier: ^0.2.8
       version: 0.2.8
     '@uni-helper/vite-plugin-uni-pages':
-      specifier: ^0.3.9
-      version: 0.3.9
+      specifier: ^0.3.11
+      version: 0.3.11
     unbuild:
-      specifier: ~3.5.0
-      version: 3.5.0
+      specifier: ~3.6.1
+      version: 3.6.1
     unplugin-auto-import:
       specifier: ^20.1.0
       version: 20.1.0
     vite:
-      specifier: ^5.4.19
-      version: 5.4.19
+      specifier: ^5.4.20
+      version: 5.4.20
+    vite-plugin-inspect:
+      specifier: ~0.8.9
+      version: 0.8.9
     vite-plugin-uni-polyfill:
       specifier: ^0.1.0
       version: 0.1.0
@@ -34,19 +37,19 @@ catalogs:
       specifier: ^1.6.3
       version: 1.6.3
     vitepress-plugin-llms:
-      specifier: ^1.7.3
-      version: 1.7.3
+      specifier: ^1.7.5
+      version: 1.7.5
   cli:
     bumpp:
       specifier: ^10.2.3
       version: 10.2.3
     pncat:
-      specifier: ^0.5.3
-      version: 0.5.3
+      specifier: ^0.5.4
+      version: 0.5.4
   dcloudio:
     '@dcloudio/types':
-      specifier: ^3.4.19
-      version: 3.4.19
+      specifier: ^3.4.21
+      version: 3.4.21
     '@dcloudio/uni-app':
       specifier: 3.0.0-4070620250821001
       version: 3.0.0-4070620250821001
@@ -148,14 +151,14 @@ catalogs:
       version: 1.2.13
   lint:
     '@xiaohe01/eslint-config':
-      specifier: ^2.2.2
-      version: 2.2.2
+      specifier: ^2.3.0
+      version: 2.3.0
     '@xiaohe01/stylelint-config':
       specifier: ^2.4.0
       version: 2.4.0
     eslint:
-      specifier: ^9.34.0
-      version: 9.34.0
+      specifier: ^9.35.0
+      version: 9.35.0
     lint-staged:
       specifier: ^16.1.6
       version: 16.1.6
@@ -163,12 +166,12 @@ catalogs:
       specifier: ^2.13.1
       version: 2.13.1
     stylelint:
-      specifier: ^16.23.1
-      version: 16.23.1
+      specifier: ^16.24.0
+      version: 16.24.0
   node:
     chalk:
-      specifier: ^5.6.0
-      version: 5.6.0
+      specifier: ^5.6.2
+      version: 5.6.2
     consola:
       specifier: ^3.4.2
       version: 3.4.2
@@ -235,7 +238,7 @@ importers:
         version: 9.2.0
       '@dcloudio/types':
         specifier: catalog:dcloudio
-        version: 3.4.19
+        version: 3.4.21
       '@mini-types/alipay':
         specifier: catalog:dev
         version: 3.0.14
@@ -247,10 +250,10 @@ importers:
         version: 1.0.0-alpha.6(typescript@5.8.3)(vue@3.4.38(typescript@5.8.3))
       '@xiaohe01/eslint-config':
         specifier: catalog:lint
-        version: 2.2.2(@vue/compiler-sfc@3.5.21)(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jsdom@16.7.0)(terser@5.44.0))
+        version: 2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0))
       '@xiaohe01/stylelint-config':
         specifier: catalog:lint
-        version: 2.4.0(postcss@8.5.6)(stylelint@16.23.1(typescript@5.8.3))
+        version: 2.4.0(postcss@8.5.6)(stylelint@16.24.0(typescript@5.8.3))
       '@xiaohe01/tsconfig':
         specifier: catalog:dev
         version: 2.0.0
@@ -259,13 +262,13 @@ importers:
         version: 10.2.3
       chalk:
         specifier: catalog:node
-        version: 5.6.0
+        version: 5.6.2
       consola:
         specifier: catalog:node
         version: 3.4.2
       eslint:
         specifier: catalog:lint
-        version: 9.34.0(jiti@2.5.1)
+        version: 9.35.0(jiti@2.5.1)
       esno:
         specifier: catalog:script
         version: 4.8.0
@@ -283,7 +286,7 @@ importers:
         version: 4.1.0
       pncat:
         specifier: catalog:cli
-        version: 0.5.3
+        version: 0.5.4
       rimraf:
         specifier: catalog:node
         version: 6.0.1
@@ -292,19 +295,19 @@ importers:
         version: 2.13.1
       stylelint:
         specifier: catalog:lint
-        version: 16.23.1(typescript@5.8.3)
+        version: 16.24.0(typescript@5.8.3)
       typescript:
         specifier: catalog:dev
         version: 5.8.3
       unbuild:
         specifier: catalog:build
-        version: 3.5.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
+        version: 3.6.1(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
       vite:
         specifier: catalog:build
-        version: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+        version: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
       vitest:
         specifier: catalog:test
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jsdom@16.7.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0)
       vue-tsc:
         specifier: catalog:frontend
         version: 2.1.10(typescript@5.8.3)
@@ -313,13 +316,13 @@ importers:
     devDependencies:
       vitepress:
         specifier: catalog:build
-        version: 1.6.4(@algolia/client-search@5.37.0)(@types/node@24.3.0)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2)
+        version: 1.6.4(@algolia/client-search@5.37.0)(@types/node@24.3.3)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2)
       vitepress-plugin-group-icons:
         specifier: catalog:build
-        version: 1.6.3(markdown-it@14.1.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))
+        version: 1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
       vitepress-plugin-llms:
         specifier: catalog:build
-        version: 1.7.3
+        version: 1.7.5
       vue:
         specifier: 3.4.38
         version: 3.4.38(typescript@5.9.2)
@@ -328,7 +331,7 @@ importers:
     devDependencies:
       '@uni-helper/vite-plugin-uni-components':
         specifier: catalog:build
-        version: 0.2.0(rollup@4.50.0)
+        version: 0.2.0(rollup@4.50.1)
       '@vue/runtime-core':
         specifier: catalog:frontend
         version: 3.4.38
@@ -355,49 +358,49 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-harmony':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-plus':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-components':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-h5':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-alipay':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-baidu':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-jd':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-kuaishou':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-lark':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-qq':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-toutiao':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-weixin':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-xhs':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-quickapp-webview':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@vueuse/core':
         specifier: catalog:utils
         version: 12.8.2(typescript@5.9.2)
@@ -422,16 +425,16 @@ importers:
     devDependencies:
       '@dcloudio/uni-automator':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-cli-shared':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-stacktracey':
         specifier: catalog:dcloudio
         version: 3.0.0-4070620250821001
       '@dcloudio/vite-plugin-uni':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@iconify-json/carbon':
         specifier: catalog:icons
         version: 1.2.13
@@ -440,19 +443,19 @@ importers:
         version: 4.17.12
       '@uni-helper/plugin-uni':
         specifier: catalog:dev
-        version: 0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       '@uni-helper/unocss-preset-uni':
         specifier: catalog:style
-        version: 0.2.11(@unocss/preset-legacy-compat@66.5.0)(@unocss/preset-mini@66.5.0)(@unocss/rule-utils@66.5.0)(@unocss/vite@66.0.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       '@uni-helper/vite-plugin-uni-components':
         specifier: catalog:build
-        version: 0.2.0(rollup@4.50.0)
+        version: 0.2.0(rollup@4.50.1)
       '@uni-helper/vite-plugin-uni-manifest':
         specifier: catalog:build
-        version: 0.2.8(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))
+        version: 0.2.8(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
       '@uni-helper/vite-plugin-uni-pages':
         specifier: catalog:build
-        version: 0.3.9(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))
+        version: 0.3.11(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
       '@vue/runtime-core':
         specifier: catalog:frontend
         version: 3.4.38
@@ -461,13 +464,16 @@ importers:
         version: 1.78.0
       unocss:
         specifier: catalog:style
-        version: 66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       unocss-applet:
         specifier: catalog:style
-        version: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       unplugin-auto-import:
         specifier: catalog:build
         version: 20.1.0(@vueuse/core@12.8.2(typescript@5.9.2))
+      vite-plugin-inspect:
+        specifier: catalog:build
+        version: 0.8.9(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
       vite-plugin-uni-polyfill:
         specifier: catalog:build
         version: 0.1.0
@@ -574,12 +580,12 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.0':
-    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
+  '@babel/compat-data@7.28.4':
+    resolution: {integrity: sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.28.3':
-    resolution: {integrity: sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==}
+  '@babel/core@7.28.4':
+    resolution: {integrity: sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.28.3':
@@ -669,12 +675,12 @@ packages:
     resolution: {integrity: sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.3':
-    resolution: {integrity: sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==}
+  '@babel/helpers@7.28.4':
+    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.3':
-    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
+  '@babel/parser@7.28.4':
+    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -841,8 +847,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-block-scoping@7.28.0':
-    resolution: {integrity: sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==}
+  '@babel/plugin-transform-block-scoping@7.28.4':
+    resolution: {integrity: sha512-1yxmvN0MJHOhPVmAsmoW5liWwoILobu/d/ShymZmj867bAdxGbehIrew1DuLpw2Ukv+qDSSPQdYW1dLNE7t11A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -859,8 +865,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
 
-  '@babel/plugin-transform-classes@7.28.3':
-    resolution: {integrity: sha512-DoEWC5SuxuARF2KdKmGUq3ghfPMO6ZzR12Dnp5gubwbeWJo4dbNWXJPVlwvh4Zlq6Z7YVvL8VFxeSOJgjsx4Sg==}
+  '@babel/plugin-transform-classes@7.28.4':
+    resolution: {integrity: sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1003,8 +1009,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-object-rest-spread@7.28.0':
-    resolution: {integrity: sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==}
+  '@babel/plugin-transform-object-rest-spread@7.28.4':
+    resolution: {integrity: sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1051,8 +1057,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regenerator@7.28.3':
-    resolution: {integrity: sha512-K3/M/a4+ESb5LEldjQb+XSrpY0nF+ZBFlTCbSnKaYAMfD8v33O6PMs4uYnOk19HlcsI8WMu3McdFPTiQHF/1/A==}
+  '@babel/plugin-transform-regenerator@7.28.4':
+    resolution: {integrity: sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1140,20 +1146,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
 
-  '@babel/runtime@7.28.3':
-    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.3':
-    resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
+  '@babel/traverse@7.28.4':
+    resolution: {integrity: sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.2':
-    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+  '@babel/types@7.28.4':
+    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -1188,8 +1194,8 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.0.0
 
-  '@dcloudio/types@3.4.19':
-    resolution: {integrity: sha512-1foayOFEAQ+jnQLt3ACsovCNjer3/fXn1I2VBpmDOzs2nk/n4UHwRLAxZV/RpxRqaGOPEvKrO/Pq+VI6sAmuRw==}
+  '@dcloudio/types@3.4.21':
+    resolution: {integrity: sha512-rsv3XfAaD/dtuVboPeYh+vPcULnWyozGaGKHWyN0dYRm7L1uypFUM30qNYMj9iNmbAENuBjV177S1gNEBIvdDA==}
 
   '@dcloudio/uni-app-harmony@3.0.0-4070620250821001':
     resolution: {integrity: sha512-HrnpvA/rfdY3Vi8/unxHP1BO83KzuCrfsvLQHf7twCSMWFDqCykOkrEhb8beTtQSDoZvJYsQPB6REDkgundp5Q==}
@@ -1333,8 +1339,8 @@ packages:
     resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
     engines: {node: '>=18'}
 
-  '@es-joy/jsdoccomment@0.52.0':
-    resolution: {integrity: sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==}
+  '@es-joy/jsdoccomment@0.56.0':
+    resolution: {integrity: sha512-c6EW+aA1w2rjqOMjbL93nZlwxp6c1Ln06vTYs5FjRRhmJXK8V/OrSXdT+pUr4aRYgjCgu8/OkiZr0tzeVrRSbw==}
     engines: {node: '>=20.11.0'}
 
   '@esbuild/aix-ppc64@0.20.2':
@@ -1775,8 +1781,8 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  '@eslint-community/eslint-utils@4.8.0':
-    resolution: {integrity: sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==}
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -1810,8 +1816,8 @@ packages:
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.34.0':
-    resolution: {integrity: sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==}
+  '@eslint/js@9.35.0':
+    resolution: {integrity: sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/markdown@7.2.0':
@@ -1830,17 +1836,13 @@ packages:
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/node@0.16.6':
-    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
-
-  '@humanwhocodes/retry@0.3.1':
-    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
-    engines: {node: '>=18.18'}
 
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
@@ -1852,8 +1854,8 @@ packages:
   '@iconify-json/logos@1.2.9':
     resolution: {integrity: sha512-G6VCdFnwZcrT6Eveq3m43oJfLw/CX8plwFcE+2jgv3fiGB64pTmnU7Yd1MNZ/eA+/Re2iEDhuCfSNOWTHwwK8w==}
 
-  '@iconify-json/simple-icons@1.2.50':
-    resolution: {integrity: sha512-Z2ggRwKYEBB9eYAEi4NqEgIzyLhu0Buh4+KGzMPD6+xG7mk52wZJwLT/glDPtfslV503VtJbqzWqBUGkCMKOFA==}
+  '@iconify-json/simple-icons@1.2.51':
+    resolution: {integrity: sha512-vFH0QEHFG3rt9hZOR3oE/ZfAKFA7cS11UXttD/IphClEbiSTsPbpeeJ4kRYGDBUDmAKhBzk6jxHNG8VipwA69Q==}
 
   '@iconify-json/vscode-icons@1.2.30':
     resolution: {integrity: sha512-dlTOc8w4a8/QNumZzMve+APJa6xQVXPZwo8qBk/MaYfY42NPrQT83QXkbTWKDkuEu/xgHPXvKZZBL7Yy12vYQw==}
@@ -2150,11 +2152,11 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@jridgewell/trace-mapping@0.3.30':
-    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@keyv/serialize@1.1.0':
-    resolution: {integrity: sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==}
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
   '@mini-types/alipay@3.0.14':
     resolution: {integrity: sha512-FakzSsKvybtWlEIVTIRlr89kuQFn+XY86Ho9VUFFaKLplhW6Wx8FUxTDE7IzV7B9rT8DP/Icy637vUHlXPsw1g==}
@@ -2232,8 +2234,8 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/pluginutils@5.2.0':
-    resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -2241,119 +2243,119 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.50.0':
-    resolution: {integrity: sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==}
+  '@rollup/rollup-android-arm-eabi@4.50.1':
+    resolution: {integrity: sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.50.0':
-    resolution: {integrity: sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==}
+  '@rollup/rollup-android-arm64@4.50.1':
+    resolution: {integrity: sha512-PZlsJVcjHfcH53mOImyt3bc97Ep3FJDXRpk9sMdGX0qgLmY0EIWxCag6EigerGhLVuL8lDVYNnSo8qnTElO4xw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.50.0':
-    resolution: {integrity: sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==}
+  '@rollup/rollup-darwin-arm64@4.50.1':
+    resolution: {integrity: sha512-xc6i2AuWh++oGi4ylOFPmzJOEeAa2lJeGUGb4MudOtgfyyjr4UPNK+eEWTPLvmPJIY/pgw6ssFIox23SyrkkJw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.50.0':
-    resolution: {integrity: sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==}
+  '@rollup/rollup-darwin-x64@4.50.1':
+    resolution: {integrity: sha512-2ofU89lEpDYhdLAbRdeyz/kX3Y2lpYc6ShRnDjY35bZhd2ipuDMDi6ZTQ9NIag94K28nFMofdnKeHR7BT0CATw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.50.0':
-    resolution: {integrity: sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==}
+  '@rollup/rollup-freebsd-arm64@4.50.1':
+    resolution: {integrity: sha512-wOsE6H2u6PxsHY/BeFHA4VGQN3KUJFZp7QJBmDYI983fgxq5Th8FDkVuERb2l9vDMs1D5XhOrhBrnqcEY6l8ZA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.50.0':
-    resolution: {integrity: sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==}
+  '@rollup/rollup-freebsd-x64@4.50.1':
+    resolution: {integrity: sha512-A/xeqaHTlKbQggxCqispFAcNjycpUEHP52mwMQZUNqDUJFFYtPHCXS1VAG29uMlDzIVr+i00tSFWFLivMcoIBQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.50.0':
-    resolution: {integrity: sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.50.1':
+    resolution: {integrity: sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.50.0':
-    resolution: {integrity: sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.50.1':
+    resolution: {integrity: sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.50.0':
-    resolution: {integrity: sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==}
+  '@rollup/rollup-linux-arm64-gnu@4.50.1':
+    resolution: {integrity: sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.50.0':
-    resolution: {integrity: sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==}
+  '@rollup/rollup-linux-arm64-musl@4.50.1':
+    resolution: {integrity: sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
-    resolution: {integrity: sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.50.1':
+    resolution: {integrity: sha512-RPhTwWMzpYYrHrJAS7CmpdtHNKtt2Ueo+BlLBjfZEhYBhK00OsEqM08/7f+eohiF6poe0YRDDd8nAvwtE/Y62Q==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.50.0':
-    resolution: {integrity: sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==}
+  '@rollup/rollup-linux-ppc64-gnu@4.50.1':
+    resolution: {integrity: sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.50.0':
-    resolution: {integrity: sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==}
+  '@rollup/rollup-linux-riscv64-gnu@4.50.1':
+    resolution: {integrity: sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.50.0':
-    resolution: {integrity: sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.50.1':
+    resolution: {integrity: sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.50.0':
-    resolution: {integrity: sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.50.1':
+    resolution: {integrity: sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.50.0':
-    resolution: {integrity: sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==}
+  '@rollup/rollup-linux-x64-gnu@4.50.1':
+    resolution: {integrity: sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.50.0':
-    resolution: {integrity: sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==}
+  '@rollup/rollup-linux-x64-musl@4.50.1':
+    resolution: {integrity: sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openharmony-arm64@4.50.0':
-    resolution: {integrity: sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==}
+  '@rollup/rollup-openharmony-arm64@4.50.1':
+    resolution: {integrity: sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.50.0':
-    resolution: {integrity: sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==}
+  '@rollup/rollup-win32-arm64-msvc@4.50.1':
+    resolution: {integrity: sha512-hpZB/TImk2FlAFAIsoElM3tLzq57uxnGYwplg6WDyAxbYczSi8O2eQ+H2Lx74504rwKtZ3N2g4bCUkiamzS6TQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.50.0':
-    resolution: {integrity: sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==}
+  '@rollup/rollup-win32-ia32-msvc@4.50.1':
+    resolution: {integrity: sha512-SXjv8JlbzKM0fTJidX4eVsH+Wmnp0/WcD8gJxIZyR6Gay5Qcsmdbi9zVtnbkGPG8v2vMR1AD06lGWy5FLMcG7A==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.50.0':
-    resolution: {integrity: sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==}
+  '@rollup/rollup-win32-x64-msvc@4.50.1':
+    resolution: {integrity: sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA==}
     cpu: [x64]
     os: [win32]
 
@@ -2473,8 +2475,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.3.0':
-    resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
+  '@types/node@24.3.3':
+    resolution: {integrity: sha512-GKBNHjoNw3Kra1Qg5UXttsY5kiWMEfoHq2TmXb+b1rcm6N7B3wTrFYIf/oSZ1xNQ+hVVijgLkiDZh7jRRsh+Gw==}
 
   '@types/prettier@2.7.3':
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
@@ -2497,63 +2499,63 @@ packages:
   '@types/yargs@16.0.9':
     resolution: {integrity: sha512-tHhzvkFXZQeTECenFoRljLBYPZJ7jAVxqqtEI0qTLOmuultnFp4I9yKE17vTuhf7BkhCu7I4XuemPgikDVuYqA==}
 
-  '@typescript-eslint/eslint-plugin@8.42.0':
-    resolution: {integrity: sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==}
+  '@typescript-eslint/eslint-plugin@8.43.0':
+    resolution: {integrity: sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.42.0
+      '@typescript-eslint/parser': ^8.43.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.42.0':
-    resolution: {integrity: sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.42.0':
-    resolution: {integrity: sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.42.0':
-    resolution: {integrity: sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.42.0':
-    resolution: {integrity: sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.42.0':
-    resolution: {integrity: sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==}
+  '@typescript-eslint/parser@8.43.0':
+    resolution: {integrity: sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.42.0':
-    resolution: {integrity: sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.42.0':
-    resolution: {integrity: sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==}
+  '@typescript-eslint/project-service@8.43.0':
+    resolution: {integrity: sha512-htB/+D/BIGoNTQYffZw4uM4NzzuolCoaA/BusuSIcC8YjmBYQioew5VUZAYdAETPjeed0hqCaW7EHg+Robq8uw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.42.0':
-    resolution: {integrity: sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==}
+  '@typescript-eslint/scope-manager@8.43.0':
+    resolution: {integrity: sha512-daSWlQ87ZhsjrbMLvpuuMAt3y4ba57AuvadcR7f3nl8eS3BjRc8L9VLxFLk92RL5xdXOg6IQ+qKjjqNEimGuAg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.43.0':
+    resolution: {integrity: sha512-ALC2prjZcj2YqqL5X/bwWQmHA2em6/94GcbB/KKu5SX3EBDOsqztmmX1kMkvAJHzxk7TazKzJfFiEIagNV3qEA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.43.0':
+    resolution: {integrity: sha512-qaH1uLBpBuBBuRf8c1mLJ6swOfzCXryhKND04Igr4pckzSEW9JX5Aw9AgW00kwfjWJF0kk0ps9ExKTfvXfw4Qg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.42.0':
-    resolution: {integrity: sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==}
+  '@typescript-eslint/types@8.43.0':
+    resolution: {integrity: sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.43.0':
+    resolution: {integrity: sha512-7Vv6zlAhPb+cvEpP06WXXy/ZByph9iL6BQRBDj4kmBsW98AqEeQHlj/13X+sZOrKSo9/rNKH4Ul4f6EICREFdw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.43.0':
+    resolution: {integrity: sha512-S1/tEmkUeeswxd0GGcnwuVQPFWo8NzZTOMxCvw8BX7OMxnNae+i8Tm7REQen/SwUIPoPqfKn7EaZ+YLpiB3k9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.43.0':
+    resolution: {integrity: sha512-T+S1KqRD4sg/bHfLwrpF/K3gQLBM1n7Rp7OjjikjTEssI2YJzQpi5WXoynOaQ93ERIuq3O8RBTOUYDKszUCEHw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -2597,8 +2599,8 @@ packages:
     peerDependencies:
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  '@uni-helper/vite-plugin-uni-pages@0.3.9':
-    resolution: {integrity: sha512-IqocjUzQ+lkosYu7RTqSf5sfOerNI9mez3/eO+Xzu/32nM2LVepineF5j1uUt3ysiWQ0Re4ixgTXks5dz93gUg==}
+  '@uni-helper/vite-plugin-uni-pages@0.3.11':
+    resolution: {integrity: sha512-LnMkZsNdItz950TX2PYomkvtYDW8lFOGfKmmAKpw2LUUD28VCnxP8E8+rzB5nLM0vyEQeMCzHe3z378R/h/snw==}
     peerDependencies:
       vite: ^5.0.0
 
@@ -2631,14 +2633,14 @@ packages:
   '@unocss/core@66.0.0':
     resolution: {integrity: sha512-PdVbSMHNDDkr++9nkqzsZRAkaU84gxMTEgYbqI7dt2p1DXp/5tomVtmMsr2/whXGYKRiUc0xZ3p4Pzraz8TcXA==}
 
-  '@unocss/core@66.5.0':
-    resolution: {integrity: sha512-4JStg50nrwd4aJulbPYglqHyuVUHMEX2EltpdxrrxknvSjy4LriKCVUCEmIljsbTFDXm8xcPnPGs6VN/ZmlKlA==}
+  '@unocss/core@66.5.1':
+    resolution: {integrity: sha512-BUgN87sUIffco1d+1IuV4a1gKTI1YAFa7CTjxglLUAnopXPPJ+Q77G10zoBoFLzutiIOYLsesa3hzbQvDhosnA==}
 
   '@unocss/extractor-arbitrary-variants@66.0.0':
     resolution: {integrity: sha512-vlkOIOuwBfaFBJcN6o7+obXjigjOlzVFN/jT6pG1WXbQDTRZ021jeF3i9INdb9D/0cQHSeDvNgi1TJ5oUxfiow==}
 
-  '@unocss/extractor-arbitrary-variants@66.5.0':
-    resolution: {integrity: sha512-Em5jrB4wPJWHRwp4hBRPWbYH/brEdQzYFC5RUSNem5u3kToYSiBid4KwBRTBHmLAdDxcrDXBD1pbDot0PAQe2g==}
+  '@unocss/extractor-arbitrary-variants@66.5.1':
+    resolution: {integrity: sha512-SpI2uv6bWyPyY3Tv7CxsFnHBjSTlNRcPCnfvD8gSKbAt7R+RqV0nrdkv7wSW+Woc5TYl8PClLEFSBIvo0c1h9Q==}
 
   '@unocss/inspector@66.0.0':
     resolution: {integrity: sha512-mkIxieVm0kMOKw+E4ABpIerihYMdjgq9A92RD5h2+W/ebpxTEw5lTTK1xcMLiAlmOrVYMQKjpgPeu3vQmDyGZQ==}
@@ -2655,14 +2657,14 @@ packages:
   '@unocss/preset-icons@66.0.0':
     resolution: {integrity: sha512-6ObwTvEGuPBbKWRoMMiDioHtwwQTFI5oojFLJ32Y8tW6TdXvBLkO88d7qpgQxEjgVt4nJrqF1WEfR4niRgBm0Q==}
 
-  '@unocss/preset-legacy-compat@66.5.0':
-    resolution: {integrity: sha512-0jmRMto2G7YAIJWLU2BNg2SYJr8/6jN24GXxNdV02DdJVGTetJj+9vQMk5UwalN4Ze11cY8sKgsa8VRADJYWxQ==}
+  '@unocss/preset-legacy-compat@66.5.1':
+    resolution: {integrity: sha512-6+6EsVR4CKKMoXWZB1yBCq/XvYb6SD/fzmpu/9b9Oq4HKJCvTnWnxHq5IYo7FBIFWduCo6WZ875MVIhKliAHMg==}
 
   '@unocss/preset-mini@66.0.0':
     resolution: {integrity: sha512-d62eACnuKtR0dwCFOQXgvw5VLh5YSyK56xCzpHkh0j0GstgfDLfKTys0T/XVAAvdSvAy/8A8vhSNJ4PlIc9V2A==}
 
-  '@unocss/preset-mini@66.5.0':
-    resolution: {integrity: sha512-aGnxlO47D0DMTEYTbwAZ/xICz8/QGUhin9hb4dsVhEorDvL1R0/qqvyjhyyIeTTDqPTxKTtczY7rP8XJqkuBXA==}
+  '@unocss/preset-mini@66.5.1':
+    resolution: {integrity: sha512-kBEbA0kEXRtoHQ98o4b6f9sp1u5BanPzi+GMnWdmOWvbLAiLw1vcgXGPTX3sO+gzIMrwu0Famw6xiztWzAFjWQ==}
 
   '@unocss/preset-tagify@66.0.0':
     resolution: {integrity: sha512-GGYGyWxaevh0jN0NoATVO1Qe7DFXM3ykLxchlXmG6/zy963pZxItg/njrKnxE9la4seCdxpFH7wQBa68imwwdA==}
@@ -2679,11 +2681,11 @@ packages:
   '@unocss/preset-wind3@66.0.0':
     resolution: {integrity: sha512-WAGRmpi1sb2skvYn9DBQUvhfqrJ+VmQmn5ZGsT2ewvsk7HFCvVLAMzZeKrrTQepeNBRhg6HzFDDi8yg6yB5c9g==}
 
-  '@unocss/preset-wind3@66.5.0':
-    resolution: {integrity: sha512-LC3I2yzmWguOOdp4gLwhJG1/Nya6v9+GH2rXRn8LNSZN5yhdz0LwqjftSIsPxbIpoi7+pkGTzOiXHfV/XXbswA==}
+  '@unocss/preset-wind3@66.5.1':
+    resolution: {integrity: sha512-L1yMmKpwUWYUnScQq5jMTGvfMy/GBqVj40VS5afyOlzWnBeSkc/y4AxeW/khzGwqE/QaFcLWXiXwQVJIyxN02Q==}
 
-  '@unocss/preset-wind4@66.5.0':
-    resolution: {integrity: sha512-kR7TPqQ8vIwXrrLticKc5CbHLGbXiRnWI7xPFduC3l8RE0VPyShegmY62KRc6tX58Tarhnsrct+Teln7ZlEWKw==}
+  '@unocss/preset-wind4@66.5.1':
+    resolution: {integrity: sha512-i6UaZ/hRabu+bvEwUJcc3k/v/tF1sjKukvtQF027zaL3Q5k5QKKhDH989wVHU1k+i+W77+og2/K9+FzXN9+CzQ==}
 
   '@unocss/preset-wind@66.0.0':
     resolution: {integrity: sha512-FtvGpHnGC7FiyKJavPnn5y9lsaoWRhXlujCqlT5Bw63kKhMNr0ogKySBpenUhJOhWhVM0OQXn2nZ3GZRxW2qpw==}
@@ -2695,8 +2697,8 @@ packages:
     resolution: {integrity: sha512-UJ51YHbwxYTGyj35ugsPlOT4gaa7tCbXdywZ3m5Nn0JgywwIqGmBFyiN9ZjHBHfJuDxmmPd6lxojoBscih/WMQ==}
     engines: {node: '>=14'}
 
-  '@unocss/rule-utils@66.5.0':
-    resolution: {integrity: sha512-+yqGZP8fR/G/gOkjXSXjmgTXFr4zGCQR+rA3Ana4xVoLIttcmPk4qO1IWcUVRQTDDqFmUjW/XwWmChta+rdQsA==}
+  '@unocss/rule-utils@66.5.1':
+    resolution: {integrity: sha512-GuBKHrDv3bdq5N1HfOr1tD864vI1EIiovBVJSfg7x9ERA4jJSnyMpGk/hbLuDIXF25EnVdZ1lFhEpJgur9+9sw==}
     engines: {node: '>=14'}
 
   '@unocss/transformer-attributify-jsx@66.0.0':
@@ -2744,8 +2746,8 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: 3.4.38
 
-  '@vitest/eslint-plugin@1.3.7':
-    resolution: {integrity: sha512-q6UIrP+wLNRSBs2YnaOFE6Y8UjCqBSVCGGE6FgzNjN5gl1vwzjAvnInvmpbu+t3BF9BYwGpUJPko8yqwUqcyWg==}
+  '@vitest/eslint-plugin@1.3.9':
+    resolution: {integrity: sha512-wsNe7xy44ovm/h9ISDkDNcv0aOnUsaOYDqan2y6qCFAUQ0odFr6df/+FdGKHZN+mCM+SvIDWoXuvm5T5V3Kh6w==}
     peerDependencies:
       eslint: '>= 8.57.0'
       typescript: '>= 5.0.0'
@@ -2951,8 +2953,8 @@ packages:
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
-  '@xiaohe01/eslint-config@2.2.2':
-    resolution: {integrity: sha512-Emp6K7OFH275/kLMwhSZRdVVlJ/Vyzk9TO55J7OJnB8pk8oVAosGB5hLgTZrsGXGTe4ayxZ9HfMTZoL06uVUBg==}
+  '@xiaohe01/eslint-config@2.3.0':
+    resolution: {integrity: sha512-cn0f15zkQWA/FHNfZvB12gBBVE4ZWNl7xZmwmAh7j+fnzE4gFmY4Eh+7tprAXC/bHrth27kRB+AWq0sfG9yvcg==}
     peerDependencies:
       '@eslint-react/eslint-plugin': ^1.38.4
       '@next/eslint-plugin-next': ^15.4.0-canary.115
@@ -3072,16 +3074,16 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
-  ansi-escapes@7.0.0:
-    resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
+  ansi-escapes@7.1.0:
+    resolution: {integrity: sha512-YdhtCd19sKRKfAAUsrcC1wzm4JuzJoiX4pOJqIoW2qmKj5WzG/dL8uUJ0361zaXtHqK7gEhOwtAtz7t3Yq3X5g==}
     engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.0:
-    resolution: {integrity: sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==}
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
@@ -3092,8 +3094,8 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
   ansis@4.1.0:
@@ -3134,9 +3136,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-kit@2.1.2:
-    resolution: {integrity: sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==}
-    engines: {node: '>=20.18.0'}
+  ast-kit@1.4.3:
+    resolution: {integrity: sha512-MdJqjpodkS5J149zN0Po+HPshkTdUyrvF7CKTafUgv69vBSPtncrj+3IiUgqdd7ElIEkbeXCsEouBUwLrw9Ilg==}
+    engines: {node: '>=16.14.0'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -3208,6 +3210,10 @@ packages:
     resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
     engines: {node: '>=6.0.0'}
 
+  baseline-browser-mapping@2.8.3:
+    resolution: {integrity: sha512-mcE+Wr2CAhHNWxXN/DdTI+n4gsPc5QpXpWnyCQWiQYIYZX+ZMJ8juXZgjRa/0/YPJo/NSsgW15/YgmI4nbysYw==}
+    hasBin: true
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -3245,8 +3251,8 @@ packages:
     peerDependencies:
       browserslist: '*'
 
-  browserslist@4.25.4:
-    resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
+  browserslist@4.26.0:
+    resolution: {integrity: sha512-P9go2WrP9FiPwLv3zqRD/Uoxo0RSHjzFCiQz7d4vbmwNqQFo9T9WCeP/Qn5EbcKQY6DBbkxEXNcpJOmncNrb7A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3272,14 +3278,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  byte-size@9.0.1:
-    resolution: {integrity: sha512-YLe9x3rabBrcI0cueCdLS2l5ONUKywcRpTs02B8KP9/Cimhj7o3ZccGrPnRvcbyHMbb7W79/3MUJl7iGgTXKEw==}
-    engines: {node: '>=12.17'}
-    peerDependencies:
-      '@75lb/nature': latest
-    peerDependenciesMeta:
-      '@75lb/nature':
-        optional: true
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3335,8 +3336,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001739:
-    resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
+  caniuse-lite@1.0.30001741:
+    resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3352,8 +3353,8 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chalk@5.6.0:
-    resolution: {integrity: sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==}
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   change-case@5.4.4:
@@ -3452,8 +3453,8 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
-  commander@14.0.0:
-    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+  commander@14.0.1:
+    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
     engines: {node: '>=20'}
 
   commander@2.20.3:
@@ -3636,8 +3637,8 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -3665,9 +3666,21 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.0:
+    resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
+    engines: {node: '>=18'}
+
+  default-browser@5.2.1:
+    resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
+    engines: {node: '>=18'}
+
   default-gateway@6.0.3:
     resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
     engines: {node: '>= 10'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -3759,8 +3772,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.213:
-    resolution: {integrity: sha512-xr9eRzSLNa4neDO0xVFrkXu3vyIzG4Ay08dApecw42Z1NbmCt+keEpXdvlYGVe0wtvY5dhW0Ay0lY0IOfsCg0Q==}
+  electron-to-chromium@1.5.218:
+    resolution: {integrity: sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==}
 
   emittery@0.8.1:
     resolution: {integrity: sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==}
@@ -3808,6 +3821,9 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  error-stack-parser-es@0.1.5:
+    resolution: {integrity: sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -3933,8 +3949,8 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-jsdoc@52.0.4:
-    resolution: {integrity: sha512-be5OzGlLExvcK13Il3noU7/v7WmAQGenTmCaBKf1pwVtPOb6X+PGFVnJad0QhMj4KKf45XjE4hbsBxv25q1fTg==}
+  eslint-plugin-jsdoc@54.7.0:
+    resolution: {integrity: sha512-u5Na4he2+6kY1rWqxzbQaAwJL3/tDCuT5ElDRc5UJ9stOeQeQ5L1JJ1kRRu7ldYMlOHMCJLsY8Mg/Tu3ExdZiQ==}
     engines: {node: '>=20.11.0'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
@@ -3945,8 +3961,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-plugin-n@17.21.3:
-    resolution: {integrity: sha512-MtxYjDZhMQgsWRm/4xYLL0i2EhusWT7itDxlJ80l1NND2AL2Vi5Mvneqv/ikG9+zpran0VsVRXTEHrpLmUZRNw==}
+  eslint-plugin-n@17.22.0:
+    resolution: {integrity: sha512-+YQ4dW8gg3eVZ3A8lL6zugEmA+Le5IEpCXsI8vKvDvSIB8gEh2N3PKqDwI+J8uLb7nphTJkwiv2e5OlnEDNvpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.23.0'
@@ -3978,8 +3994,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-plugin-unicorn@60.0.0:
-    resolution: {integrity: sha512-QUzTefvP8stfSXsqKQ+vBQSEsXIlAiCduS/V1Em+FKgL9c21U/IIm20/e3MFy1jyCf14tHAhqC1sX8OTy6VUCg==}
+  eslint-plugin-unicorn@61.0.2:
+    resolution: {integrity: sha512-zLihukvneYT7f74GNbVJXfWIiNQmkc/a9vYBTE4qPkQZswolWNdu+Wsp9sIXno1JOzdn6OUwLPd19ekXVkahRA==}
     engines: {node: ^20.10.0 || >=21.0.0}
     peerDependencies:
       eslint: '>=9.29.0'
@@ -4028,8 +4044,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.34.0:
-    resolution: {integrity: sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==}
+  eslint@9.35.0:
+    resolution: {integrity: sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -4286,8 +4302,8 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.3.1:
-    resolution: {integrity: sha512-R1QfovbPsKmosqTnPoRFiJ7CF9MLRgb53ChvMZm+r4p76/+8yKDy17qLL2PKInORy2RkZZekuK0efYgmzTkXyQ==}
+  get-east-asian-width@1.4.0:
+    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -4360,8 +4376,8 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
-  globals@16.3.0:
-    resolution: {integrity: sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==}
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
     engines: {node: '>=18'}
 
   globby@11.1.0:
@@ -4545,6 +4561,11 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -4575,6 +4596,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
@@ -4615,6 +4641,10 @@ packages:
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
+
+  is-wsl@3.1.0:
+    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+    engines: {node: '>=16'}
 
   isbinaryfile@5.0.6:
     resolution: {integrity: sha512-I+NmIfBHUl+r2wcDd6JwE9yWje/PIVY/R5/CmV8dXLZd5K+L9X2klAOwfAHNnondLXkbHyTAleQAWonpTJBTtw==}
@@ -4821,6 +4851,10 @@ packages:
     resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
     engines: {node: '>=12.0.0'}
 
+  jsdoc-type-pratt-parser@5.1.1:
+    resolution: {integrity: sha512-DYYlVP1fe4QBMh2xTIs20/YeTz2GYVbWAEZweHSZD+qQ/Cx2d5RShuhhsdk64eTjNq0FeVnteP/qVOgaywSRbg==}
+    engines: {node: '>=12.0.0'}
+
   jsdom@16.7.0:
     resolution: {integrity: sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==}
     engines: {node: '>=10'}
@@ -4873,8 +4907,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  keyv@5.5.0:
-    resolution: {integrity: sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==}
+  keyv@5.5.1:
+    resolution: {integrity: sha512-eF3cHZ40bVsjdlRi/RvKAuB0+B61Q1xWvohnrJrnaQslM3h1n79IV+mc9EGag4nrA9ZOlNyr3TUzW5c8uy8vNA==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -5006,15 +5040,15 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
-  lru-cache@11.1.0:
-    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  magic-string@0.30.18:
-    resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
+  magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -5244,10 +5278,6 @@ packages:
   min-document@2.19.0:
     resolution: {integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==}
 
-  min-indent@1.0.1:
-    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
-    engines: {node: '>=4'}
-
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
@@ -5300,15 +5330,15 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  mkdist@2.3.0:
-    resolution: {integrity: sha512-thkRk+pHdudjdZT3FJpPZ2+pncI6mGlH/B+KBVddlZj4MrFGW41sRIv1wZawZUHU8v7cttGaj+5nx8P+dG664A==}
+  mkdist@2.4.1:
+    resolution: {integrity: sha512-Ezk0gi04GJBkqMfsksICU5Rjoemc4biIekwgrONWVPor2EO/N9nBgN6MZXAf7Yw4mDDhrNyKbdETaHNevfumKg==}
     hasBin: true
     peerDependencies:
-      sass: ^1.85.0
-      typescript: '>=5.7.3'
+      sass: ^1.92.1
+      typescript: '>=5.9.2'
       vue: 3.4.38
       vue-sfc-transformer: ^0.1.1
-      vue-tsc: ^1.8.27 || ^2.0.21
+      vue-tsc: ^1.8.27 || ^2.0.21 || ^3.0.0
     peerDependenciesMeta:
       sass:
         optional: true
@@ -5340,8 +5370,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nano-spawn@1.0.2:
-    resolution: {integrity: sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==}
+  nano-spawn@1.0.3:
+    resolution: {integrity: sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA==}
     engines: {node: '>=20.17'}
 
   nanoid@3.3.11:
@@ -5366,8 +5396,8 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.19:
-    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+  node-releases@2.0.21:
+    resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -5388,8 +5418,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nwsapi@2.2.21:
-    resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
+  nwsapi@2.2.22:
+    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
 
   nypm@0.5.4:
     resolution: {integrity: sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==}
@@ -5431,6 +5461,10 @@ packages:
 
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5633,8 +5667,8 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
-  pncat@0.5.3:
-    resolution: {integrity: sha512-nZsKYxIYprLskVMhoTV+r1MazFF8SznfiYJlCQL4aDEtPOSqBu0rFlcWafCBIjGMTs+L6I5lQx2D/mZsH/c4cQ==}
+  pncat@0.5.4:
+    resolution: {integrity: sha512-LxIXf+G8f9Mgorv37x3sATMfgpbY+Mtvzq3dp2+AJ0Do6dkx4zZ9dXh4AOHzDiRB3eOhsypwyfWzKjjGtBVK1A==}
     hasBin: true
 
   pngjs@3.4.0:
@@ -5907,16 +5941,16 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  preact@10.27.1:
-    resolution: {integrity: sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==}
+  preact@10.27.2:
+    resolution: {integrity: sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  pretty-bytes@6.1.1:
-    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
-    engines: {node: ^14.13.1 || >=16.0.0}
+  pretty-bytes@7.0.1:
+    resolution: {integrity: sha512-285/jRCYIbMGDciDdrw0KPNC4LKEEwz/bwErcYNxSJOi4CpGUuLpb9gQpg3XJP0XYj9ldSRluXxih4lX2YN8Xw==}
+    engines: {node: '>=20'}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -6001,8 +6035,8 @@ packages:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  regenerate-unicode-properties@10.2.0:
-    resolution: {integrity: sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==}
+  regenerate-unicode-properties@10.2.2:
+    resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
     engines: {node: '>=4'}
 
   regenerate@1.4.2:
@@ -6031,8 +6065,8 @@ packages:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
 
-  regexpu-core@6.2.0:
-    resolution: {integrity: sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==}
+  regexpu-core@6.3.1:
+    resolution: {integrity: sha512-DzcswPr252wEr7Qz8AyAVbfyBDKLoYp6eRA1We2Fa9qirRFSdtkP5sHr3yglDKy2BbA0fd2T+j/CUSKes3FeVQ==}
     engines: {node: '>=4'}
 
   regjsgen@0.8.0:
@@ -6121,10 +6155,14 @@ packages:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0
 
-  rollup@4.50.0:
-    resolution: {integrity: sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==}
+  rollup@4.50.1:
+    resolution: {integrity: sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -6225,8 +6263,8 @@ packages:
     resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
     hasBin: true
 
-  sirv@3.0.1:
-    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
   sisteransi@1.0.5:
@@ -6244,8 +6282,8 @@ packages:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
 
-  slice-ansi@7.1.0:
-    resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
   source-map-js@1.2.1:
@@ -6326,8 +6364,8 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
   strip-bom-string@1.0.0:
@@ -6346,8 +6384,8 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
-  strip-indent@4.0.0:
-    resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
+  strip-indent@4.1.0:
+    resolution: {integrity: sha512-OA95x+JPmL7kc7zCu+e+TeYxEiaIyndRx0OrBcK2QPPH09oAndr2ALvymxWA+Lx1PYYvFUm4O63pRkdJAaW96w==}
     engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
@@ -6363,8 +6401,8 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
-  stylelint-config-recess-order@7.2.0:
-    resolution: {integrity: sha512-3Y97dhsWkUHFKRLGNLF6LE5JuNB2EVAZKYJ41wBRK4gplYdk7eHhSIwE24hanu0AoNmv5534Djip70pE+y5qkA==}
+  stylelint-config-recess-order@7.3.0:
+    resolution: {integrity: sha512-1LZhQi/D6OljSLRKejMEzbZA8h0AKkJH7p2y+eValc9ltWRGVznjnZsNLVCOwYpKk7GlYMLNVYTc9WpA0W3TYQ==}
     peerDependencies:
       stylelint: '>=16.18'
       stylelint-order: '>=7'
@@ -6381,8 +6419,8 @@ packages:
     peerDependencies:
       stylelint: ^16.0.2
 
-  stylelint@16.23.1:
-    resolution: {integrity: sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==}
+  stylelint@16.24.0:
+    resolution: {integrity: sha512-7ksgz3zJaSbTUGr/ujMXvLVKdDhLbGl3R/3arNudH7z88+XZZGNLMTepsY28WlnvEFcuOmUe7fg40Q3lfhOfSQ==}
     engines: {node: '>=18.12.0'}
     hasBin: true
 
@@ -6474,8 +6512,8 @@ packages:
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
-  tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -6580,11 +6618,11 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
-  unbuild@3.5.0:
-    resolution: {integrity: sha512-DPFttsiADnHRb/K+yJ9r9jdn6JyXlsmdT0S12VFC14DFSJD+cxBnHq+v0INmqqPVPxOoUjvJFYUVIb02rWnVeA==}
+  unbuild@3.6.1:
+    resolution: {integrity: sha512-+U5CdtrdjfWkZhuO4N9l5UhyiccoeMEXIc2Lbs30Haxb+tRwB3VwB8AoZRxlAzORXunenSo+j6lh45jx+xkKgg==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.7.3
+      typescript: ^5.9.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6606,8 +6644,8 @@ packages:
     resolution: {integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==}
     engines: {node: '>=4'}
 
-  unicode-match-property-value-ecmascript@2.2.0:
-    resolution: {integrity: sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==}
+  unicode-match-property-value-ecmascript@2.2.1:
+    resolution: {integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==}
     engines: {node: '>=4'}
 
   unicode-property-aliases-ecmascript@2.1.0:
@@ -6764,11 +6802,21 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-plugin-inspect@0.8.9:
+    resolution: {integrity: sha512-22/8qn+LYonzibb1VeFZmISdVao5kC22jmEKm24vfFE8siEn47EpVcCLYMv6iKOYMJfjSvSJfueOwcFCkUnV3A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@nuxt/kit': '*'
+      vite: ^3.1.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.1
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+
   vite-plugin-uni-polyfill@0.1.0:
     resolution: {integrity: sha512-xCg+w9iqvHRrwEyc3/7LKB4wJz24oEaWarn77tYA+g2eMpe0AVdUxaG4g7ZS3C/Hn7n4zV1ZxyFOQ4zNF5jBAg==}
 
-  vite@5.4.19:
-    resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
+  vite@5.4.20:
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -6804,8 +6852,8 @@ packages:
       markdown-it: '>=14'
       vite: '>=3'
 
-  vitepress-plugin-llms@1.7.3:
-    resolution: {integrity: sha512-XhTVbUrKwrzrwlRKd/zT2owvjwi5cdB21HgDRcHqp9PYK4Fy+mBYJUoTcLaJ5IKD1DDrJZMo0DuJeyC5RSDI9Q==}
+  vitepress-plugin-llms@1.7.5:
+    resolution: {integrity: sha512-GTkuxwIUt2QkK2GhNdn1iBtl0Zv7U6nw5hqIBhsiclS7elwjvu4TIyzDPO/oYD2E1ZKDhz3PGmTzvNj9LEgLaA==}
 
   vitepress@1.6.4:
     resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
@@ -6955,8 +7003,8 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrap-ansi@9.0.0:
-    resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
   wrappy@1.0.2:
@@ -6992,6 +7040,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   xhr@2.6.0:
     resolution: {integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==}
@@ -7202,7 +7254,7 @@ snapshots:
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -7228,22 +7280,22 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.0': {}
+  '@babel/compat-data@7.28.4': {}
 
-  '@babel/core@7.28.3':
+  '@babel/core@7.28.4':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.3
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
-      '@babel/helpers': 7.28.3
-      '@babel/parser': 7.28.3
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
+      '@babel/helpers': 7.28.4
+      '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
+      '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7252,50 +7304,50 @@ snapshots:
 
   '@babel/generator@7.28.3':
     dependencies:
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.28.4
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.28.3)':
+  '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.3)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.28.3)':
+  '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.27.3
-      regexpu-core: 6.2.0
+      regexpu-core: 6.3.1
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.3)':
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.1
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -7305,55 +7357,55 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.3)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.3)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.3)':
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
@@ -7366,603 +7418,603 @@ snapshots:
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helpers@7.28.3':
+  '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
 
-  '@babel/parser@7.28.3':
+  '@babel/parser@7.28.4':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.3)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.3)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.3)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.3)':
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.3)
-      '@babel/traverse': 7.28.3
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.4)
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.3)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.28.3)':
+  '@babel/plugin-transform-block-scoping@7.28.4(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.28.3)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.3(@babel/core@7.28.3)':
+  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.4)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.4(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.3)
-      '@babel/traverse': 7.28.3
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.4)
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.27.2
 
-  '@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.28.3)':
+  '@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.3)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.3)
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.3)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-object-rest-spread@7.28.0(@babel/core@7.28.3)':
+  '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.3)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.3)
-      '@babel/traverse': 7.28.3
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.4)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.4)
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.3)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.3)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.3)
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regenerator@7.28.3(@babel/core@7.28.3)':
+  '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-typescript@7.28.0(@babel/core@7.28.3)':
+  '@babel/plugin-transform-typescript@7.28.0(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.3)
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.3)':
+  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.4)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/preset-env@7.28.3(@babel/core@7.28.3)':
+  '@babel/preset-env@7.28.3(@babel/core@7.28.4)':
     dependencies:
-      '@babel/compat-data': 7.28.0
-      '@babel/core': 7.28.3
+      '@babel/compat-data': 7.28.4
+      '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.28.3)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.3)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.28.3)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-block-scoping': 7.28.0(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.3)
-      '@babel/plugin-transform-classes': 7.28.3(@babel/core@7.28.3)
-      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.3)
-      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.28.3)
-      '@babel/plugin-transform-exponentiation-operator': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-logical-assignment-operators': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-systemjs': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.28.3)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.3)
-      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-regenerator': 7.28.3(@babel/core@7.28.3)
-      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.28.3)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.3)
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.3)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.3)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.3)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.28.4)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.4)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.28.4)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-block-scoping': 7.28.4(@babel/core@7.28.4)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.28.4)
+      '@babel/plugin-transform-classes': 7.28.4(@babel/core@7.28.4)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.4)
+      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.28.4)
+      '@babel/plugin-transform-exponentiation-operator': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-logical-assignment-operators': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-modules-systemjs': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.4)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.4)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-regenerator': 7.28.4(@babel/core@7.28.4)
+      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.28.4)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.4)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.4)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.4)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.4)
       core-js-compat: 3.45.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.3)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.4)':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
       esutils: 2.0.3
 
-  '@babel/runtime@7.28.3': {}
+  '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
 
-  '@babel/traverse@7.28.3':
+  '@babel/traverse@7.28.4':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.3
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
-      debug: 4.4.1
+      '@babel/types': 7.28.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.28.2':
+  '@babel/types@7.28.4':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -7995,13 +8047,13 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.0
 
-  '@dcloudio/types@3.4.19': {}
+  '@dcloudio/types@3.4.21': {}
 
-  '@dcloudio/uni-app-harmony@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-harmony@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      debug: 4.4.1
+      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      debug: 4.4.3
       fs-extra: 10.1.0
       licia: 1.48.0
       postcss-selector-parser: 6.1.2
@@ -8015,12 +8067,12 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-plus@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-plus@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-vue': 3.0.0-4070620250821001
-      debug: 4.4.1
+      debug: 4.4.3
       fs-extra: 10.1.0
       licia: 1.48.0
       postcss-selector-parser: 6.1.2
@@ -8034,29 +8086,29 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-uts@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-uts@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-nvue-styler': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@jridgewell/trace-mapping': 0.3.31
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/consolidate': 1.0.0
       '@vue/shared': 3.4.21
-      debug: 4.4.1
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       estree-walker: 2.0.2
       fast-glob: 3.3.3
       fs-extra: 10.1.0
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       picocolors: 1.1.1
       source-map-js: 1.2.1
       unimport: 4.1.1
@@ -8069,17 +8121,17 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-app-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-nvue-styler': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
-      debug: 4.4.1
+      debug: 4.4.3
       fs-extra: 10.1.0
       picocolors: 1.1.1
     transitivePeerDependencies:
@@ -8094,16 +8146,16 @@ snapshots:
 
   '@dcloudio/uni-app-vue@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-app@3.0.0-4070620250821001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/types': 3.4.19
-      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-components': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/types': 3.4.21
+      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-components': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
-      '@dcloudio/uni-push': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-push': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@dcloudio/uni-stat': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-stat': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@vue/shared': 3.4.21
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8114,12 +8166,12 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-automator@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-automator@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       address: 1.2.2
       cross-env: 7.0.3
-      debug: 4.4.1
+      debug: 4.4.3
       default-gateway: 6.0.3
       fs-extra: 10.1.0
       jest: 27.0.4
@@ -8141,19 +8193,19 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-cli-shared@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-cli-shared@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.28.3
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/core': 7.28.4
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@intlify/core-base': 9.1.9
       '@intlify/shared': 9.1.9
       '@intlify/vue-devtools': 9.1.9
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -8165,7 +8217,7 @@ snapshots:
       base64url: 3.0.1
       chokidar: 3.6.0
       compare-versions: 3.6.0
-      debug: 4.4.1
+      debug: 4.4.3
       entities: 4.5.0
       es-module-lexer: 1.7.0
       esbuild: 0.20.2
@@ -8176,7 +8228,7 @@ snapshots:
       isbinaryfile: 5.0.6
       jsonc-parser: 3.3.1
       lines-and-columns: 2.0.4
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       merge: 2.1.1
       mime: 3.0.0
       module-alias: 2.2.3
@@ -8201,9 +8253,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cloud@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-cloud@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8217,10 +8269,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-components@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-components@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-h5': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-h5': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8231,9 +8283,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-console@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-console@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8244,16 +8296,16 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-h5-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-h5-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/server-renderer': 3.4.21(vue@3.4.38(typescript@5.9.2))
       '@vue/shared': 3.4.21
-      debug: 4.4.1
+      debug: 4.4.3
       fs-extra: 10.1.0
       mime: 3.0.0
       module-alias: 2.2.3
@@ -8273,15 +8325,15 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@dcloudio/uni-h5@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-h5@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-h5-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-h5-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-h5-vue': 3.0.0-4070620250821001(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/server-renderer': 3.4.21(vue@3.4.38(typescript@5.9.2))
       '@vue/shared': 3.4.21
-      debug: 4.4.1
+      debug: 4.4.3
       localstorage-polyfill: 1.0.1
       postcss-selector-parser: 6.1.2
       safe-area-insets: 1.4.1
@@ -8298,10 +8350,10 @@ snapshots:
 
   '@dcloudio/uni-i18n@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-mp-alipay@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-alipay@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8315,14 +8367,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-baidu@3.0.0-4070620250821001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-baidu@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app': 3.0.0-4070620250821001(@dcloudio/types@3.4.19)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app': 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -8344,12 +8396,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-compiler@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-compiler@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/generator': 7.28.3
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
@@ -8364,11 +8416,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-jd@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-jd@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8381,13 +8433,13 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-kuaishou@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-kuaishou@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -8403,12 +8455,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-lark@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-lark@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-toutiao': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-toutiao': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8422,10 +8474,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-qq@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-qq@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8439,11 +8491,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-toutiao@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-toutiao@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8457,17 +8509,17 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/shared': 3.4.21
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -8482,10 +8534,10 @@ snapshots:
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
 
-  '@dcloudio/uni-mp-weixin@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-weixin@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8506,11 +8558,11 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-xhs@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-xhs@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8528,9 +8580,9 @@ snapshots:
       parse-css-font: 4.0.0
       postcss: 8.5.6
 
-  '@dcloudio/uni-push@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-push@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -8540,10 +8592,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-quickapp-webview@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-quickapp-webview@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8562,11 +8614,11 @@ snapshots:
 
   '@dcloudio/uni-stacktracey@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-stat@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-stat@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -8576,34 +8628,34 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.3)
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vue@3.4.38(typescript@5.9.2))
+      '@babel/core': 7.28.4
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
-      '@vitejs/plugin-legacy': 5.3.2(terser@5.44.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@vitejs/plugin-legacy': 5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/shared': 3.4.21
       cac: 6.7.9
-      debug: 4.4.1
+      debug: 4.4.3
       estree-walker: 2.0.2
       express: 4.21.2
       fast-glob: 3.3.3
       fs-extra: 10.1.0
       hash-sum: 2.0.0
       jsonc-parser: 3.3.1
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       picocolors: 1.1.1
       terser: 5.44.0
       unplugin-auto-import: 19.1.0(@vueuse/core@12.8.2(typescript@5.9.2))
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -8618,7 +8670,7 @@ snapshots:
   '@docsearch/js@3.8.2(@algolia/client-search@5.37.0)(search-insights@2.17.3)':
     dependencies:
       '@docsearch/react': 3.8.2(@algolia/client-search@5.37.0)(search-insights@2.17.3)
-      preact: 10.27.1
+      preact: 10.27.2
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -8642,18 +8694,18 @@ snapshots:
   '@es-joy/jsdoccomment@0.50.2':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.42.0
+      '@typescript-eslint/types': 8.43.0
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
 
-  '@es-joy/jsdoccomment@0.52.0':
+  '@es-joy/jsdoccomment@0.56.0':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.42.0
+      '@typescript-eslint/types': 8.43.0
       comment-parser: 1.4.1
       esquery: 1.6.0
-      jsdoc-type-pratt-parser: 4.1.0
+      jsdoc-type-pratt-parser: 5.1.1
 
   '@esbuild/aix-ppc64@0.20.2':
     optional: true
@@ -8871,27 +8923,27 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.34.0(jiti@2.5.1))':
+  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.35.0(jiti@2.5.1))':
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       ignore: 5.3.2
 
-  '@eslint-community/eslint-utils@4.8.0(eslint@9.34.0(jiti@2.5.1))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.35.0(jiti@2.5.1))':
     dependencies:
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.3.2(eslint@9.34.0(jiti@2.5.1))':
+  '@eslint/compat@1.3.2(eslint@9.35.0(jiti@2.5.1))':
     optionalDependencies:
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
 
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8905,7 +8957,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -8916,7 +8968,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.34.0': {}
+  '@eslint/js@9.35.0': {}
 
   '@eslint/markdown@7.2.0':
     dependencies:
@@ -8941,14 +8993,12 @@ snapshots:
 
   '@humanfs/core@0.19.1': {}
 
-  '@humanfs/node@0.16.6':
+  '@humanfs/node@0.16.7':
     dependencies:
       '@humanfs/core': 0.19.1
-      '@humanwhocodes/retry': 0.3.1
+      '@humanwhocodes/retry': 0.4.3
 
   '@humanwhocodes/module-importer@1.0.1': {}
-
-  '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
 
@@ -8960,7 +9010,7 @@ snapshots:
     dependencies:
       '@iconify/types': 2.0.0
 
-  '@iconify-json/simple-icons@1.2.50':
+  '@iconify-json/simple-icons@1.2.51':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -8975,7 +9025,7 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 8.1.1
       '@iconify/types': 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 15.15.0
       kolorist: 1.8.0
       local-pkg: 1.1.2
@@ -8988,7 +9038,7 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 9.2.0
       '@iconify/types': 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 15.15.0
       kolorist: 1.8.0
       local-pkg: 1.1.2
@@ -9041,7 +9091,7 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
+      strip-ansi: 7.1.2
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -9059,7 +9109,7 @@ snapshots:
   '@jest/console@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -9072,7 +9122,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -9106,14 +9156,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       jest-mock: 27.5.1
 
   '@jest/fake-timers@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -9131,7 +9181,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -9178,7 +9228,7 @@ snapshots:
 
   '@jest/transform@27.5.1':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@jest/types': 27.5.1
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -9200,13 +9250,13 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
   '@jimp/bmp@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       bmp-js: 0.1.0
@@ -9214,7 +9264,7 @@ snapshots:
 
   '@jimp/core@0.10.3':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/utils': 0.10.3
       any-base: 1.1.0
       buffer: 5.7.1
@@ -9231,7 +9281,7 @@ snapshots:
 
   '@jimp/custom@0.10.3':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/core': 0.10.3
       core-js: 3.45.1
     transitivePeerDependencies:
@@ -9239,7 +9289,7 @@ snapshots:
 
   '@jimp/gif@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
@@ -9247,7 +9297,7 @@ snapshots:
 
   '@jimp/jpeg@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
@@ -9255,28 +9305,28 @@ snapshots:
 
   '@jimp/plugin-blit@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-blur@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-circle@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-color@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
@@ -9284,7 +9334,7 @@ snapshots:
 
   '@jimp/plugin-contain@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-blit@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-scale@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3)))':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-blit': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/plugin-resize': 0.10.3(@jimp/custom@0.10.3)
@@ -9294,7 +9344,7 @@ snapshots:
 
   '@jimp/plugin-cover@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-crop@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-scale@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3)))':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-crop': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/plugin-resize': 0.10.3(@jimp/custom@0.10.3)
@@ -9304,35 +9354,35 @@ snapshots:
 
   '@jimp/plugin-crop@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-displace@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-dither@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-fisheye@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-flip@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-rotate@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-blit@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-crop@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3)))':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-rotate': 0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-blit@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-crop@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3))
       '@jimp/utils': 0.10.3
@@ -9340,35 +9390,35 @@ snapshots:
 
   '@jimp/plugin-gaussian@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-invert@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-mask@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-normalize@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-print@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-blit@0.10.3(@jimp/custom@0.10.3))':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-blit': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/utils': 0.10.3
@@ -9379,14 +9429,14 @@ snapshots:
 
   '@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
 
   '@jimp/plugin-rotate@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-blit@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-crop@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3))':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-blit': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/plugin-crop': 0.10.3(@jimp/custom@0.10.3)
@@ -9396,7 +9446,7 @@ snapshots:
 
   '@jimp/plugin-scale@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3))':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-resize': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/utils': 0.10.3
@@ -9404,7 +9454,7 @@ snapshots:
 
   '@jimp/plugin-shadow@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-blur@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3))':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-blur': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/plugin-resize': 0.10.3(@jimp/custom@0.10.3)
@@ -9413,7 +9463,7 @@ snapshots:
 
   '@jimp/plugin-threshold@0.10.3(@jimp/custom@0.10.3)(@jimp/plugin-color@0.10.3(@jimp/custom@0.10.3))(@jimp/plugin-resize@0.10.3(@jimp/custom@0.10.3))':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-color': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/plugin-resize': 0.10.3(@jimp/custom@0.10.3)
@@ -9422,7 +9472,7 @@ snapshots:
 
   '@jimp/plugins@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugin-blit': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/plugin-blur': 0.10.3(@jimp/custom@0.10.3)
@@ -9452,7 +9502,7 @@ snapshots:
 
   '@jimp/png@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/utils': 0.10.3
       core-js: 3.45.1
@@ -9460,14 +9510,14 @@ snapshots:
 
   '@jimp/tiff@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       core-js: 3.45.1
       utif: 2.0.1
 
   '@jimp/types@0.10.3(@jimp/custom@0.10.3)':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/bmp': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/custom': 0.10.3
       '@jimp/gif': 0.10.3(@jimp/custom@0.10.3)
@@ -9479,35 +9529,35 @@ snapshots:
 
   '@jimp/utils@0.10.3':
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       core-js: 3.45.1
       regenerator-runtime: 0.13.11
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/source-map@0.3.11':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@jridgewell/trace-mapping@0.3.30':
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@keyv/serialize@1.1.0': {}
+  '@keyv/serialize@1.1.1': {}
 
   '@mini-types/alipay@3.0.14':
     dependencies:
@@ -9538,114 +9588,114 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rollup/plugin-alias@5.1.1(rollup@4.50.0)':
+  '@rollup/plugin-alias@5.1.1(rollup@4.50.1)':
     optionalDependencies:
-      rollup: 4.50.0
+      rollup: 4.50.1
 
-  '@rollup/plugin-commonjs@28.0.6(rollup@4.50.0)':
+  '@rollup/plugin-commonjs@28.0.6(rollup@4.50.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
       is-reference: 1.2.1
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.50.0
+      rollup: 4.50.1
 
-  '@rollup/plugin-json@6.1.0(rollup@4.50.0)':
+  '@rollup/plugin-json@6.1.0(rollup@4.50.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
     optionalDependencies:
-      rollup: 4.50.0
+      rollup: 4.50.1
 
-  '@rollup/plugin-node-resolve@16.0.1(rollup@4.50.0)':
+  '@rollup/plugin-node-resolve@16.0.1(rollup@4.50.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.50.0
+      rollup: 4.50.1
 
-  '@rollup/plugin-replace@6.0.2(rollup@4.50.0)':
+  '@rollup/plugin-replace@6.0.2(rollup@4.50.1)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
-      magic-string: 0.30.18
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      magic-string: 0.30.19
     optionalDependencies:
-      rollup: 4.50.0
+      rollup: 4.50.1
 
-  '@rollup/pluginutils@5.2.0(rollup@4.50.0)':
+  '@rollup/pluginutils@5.3.0(rollup@4.50.1)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.50.0
+      rollup: 4.50.1
 
-  '@rollup/rollup-android-arm-eabi@4.50.0':
+  '@rollup/rollup-android-arm-eabi@4.50.1':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.50.0':
+  '@rollup/rollup-android-arm64@4.50.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.50.0':
+  '@rollup/rollup-darwin-arm64@4.50.1':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.50.0':
+  '@rollup/rollup-darwin-x64@4.50.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.50.0':
+  '@rollup/rollup-freebsd-arm64@4.50.1':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.50.0':
+  '@rollup/rollup-freebsd-x64@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.50.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.50.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.50.0':
+  '@rollup/rollup-linux-arm64-gnu@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.50.0':
+  '@rollup/rollup-linux-arm64-musl@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
+  '@rollup/rollup-linux-loongarch64-gnu@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.50.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.50.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.50.0':
+  '@rollup/rollup-linux-riscv64-musl@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.50.0':
+  '@rollup/rollup-linux-s390x-gnu@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.50.0':
+  '@rollup/rollup-linux-x64-gnu@4.50.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.50.0':
+  '@rollup/rollup-linux-x64-musl@4.50.1':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.50.0':
+  '@rollup/rollup-openharmony-arm64@4.50.1':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.50.0':
+  '@rollup/rollup-win32-arm64-msvc@4.50.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.50.0':
+  '@rollup/rollup-win32-ia32-msvc@4.50.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.50.0':
+  '@rollup/rollup-win32-x64-msvc@4.50.1':
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -9700,11 +9750,11 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 1.8.6
 
-  '@stylistic/eslint-plugin@5.3.1(eslint@9.34.0(jiti@2.5.1))':
+  '@stylistic/eslint-plugin@5.3.1(eslint@9.35.0(jiti@2.5.1))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
-      '@typescript-eslint/types': 8.42.0
-      eslint: 9.34.0(jiti@2.5.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@typescript-eslint/types': 8.43.0
+      eslint: 9.35.0(jiti@2.5.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -9714,24 +9764,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
 
   '@types/chai@5.2.2':
     dependencies:
@@ -9748,11 +9798,11 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
 
   '@types/hast@3.0.4':
     dependencies:
@@ -9772,7 +9822,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
 
   '@types/linkify-it@5.0.0': {}
 
@@ -9795,7 +9845,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.3.0':
+  '@types/node@24.3.3':
     dependencies:
       undici-types: 7.10.0
 
@@ -9815,15 +9865,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.42.0
-      '@typescript-eslint/type-utils': 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.42.0
-      eslint: 9.34.0(jiti@2.5.1)
+      '@typescript-eslint/parser': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.43.0
+      '@typescript-eslint/type-utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.43.0
+      eslint: 9.35.0(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -9832,57 +9882,57 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.42.0
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/typescript-estree': 8.42.0(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.42.0
-      debug: 4.4.1
-      eslint: 9.34.0(jiti@2.5.1)
+      '@typescript-eslint/scope-manager': 8.43.0
+      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/typescript-estree': 8.43.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.43.0
+      debug: 4.4.3
+      eslint: 9.35.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.42.0(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.43.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.42.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.42.0
-      debug: 4.4.1
+      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.43.0
+      debug: 4.4.3
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.42.0':
+  '@typescript-eslint/scope-manager@8.43.0':
     dependencies:
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/visitor-keys': 8.42.0
+      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/visitor-keys': 8.43.0
 
-  '@typescript-eslint/tsconfig-utils@8.42.0(typescript@5.8.3)':
+  '@typescript-eslint/tsconfig-utils@8.43.0(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/typescript-estree': 8.42.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      debug: 4.4.1
-      eslint: 9.34.0(jiti@2.5.1)
+      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/typescript-estree': 8.43.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      debug: 4.4.3
+      eslint: 9.35.0(jiti@2.5.1)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.42.0': {}
+  '@typescript-eslint/types@8.43.0': {}
 
-  '@typescript-eslint/typescript-estree@8.42.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.43.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.42.0(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.42.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/visitor-keys': 8.42.0
-      debug: 4.4.1
+      '@typescript-eslint/project-service': 8.43.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/visitor-keys': 8.43.0
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -9892,27 +9942,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
-      '@typescript-eslint/scope-manager': 8.42.0
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/typescript-estree': 8.42.0(typescript@5.8.3)
-      eslint: 9.34.0(jiti@2.5.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@typescript-eslint/scope-manager': 8.43.0
+      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/typescript-estree': 8.43.0(typescript@5.8.3)
+      eslint: 9.35.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.42.0':
+  '@typescript-eslint/visitor-keys@8.43.0':
     dependencies:
-      '@typescript-eslint/types': 8.42.0
+      '@typescript-eslint/types': 8.43.0
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@uni-helper/plugin-uni@0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
+  '@uni-helper/plugin-uni@0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
     dependencies:
-      '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
   '@uni-helper/uni-app-types@1.0.0-alpha.6(typescript@5.8.3)(vue@3.4.38(typescript@5.8.3))':
     dependencies:
@@ -9923,86 +9973,86 @@ snapshots:
     dependencies:
       std-env: 3.9.0
 
-  '@uni-helper/unocss-preset-uni@0.2.11(@unocss/preset-legacy-compat@66.5.0)(@unocss/preset-mini@66.5.0)(@unocss/rule-utils@66.5.0)(@unocss/vite@66.0.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
+  '@uni-helper/unocss-preset-uni@0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
     dependencies:
       '@uni-helper/uni-env': 0.1.8
-      '@unocss/preset-legacy-compat': 66.5.0
-      '@unocss/rule-utils': 66.5.0
-      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      unocss-applet: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+      '@unocss/preset-legacy-compat': 66.5.1
+      '@unocss/rule-utils': 66.5.1
+      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      unocss-applet: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
     optionalDependencies:
-      '@unocss/preset-mini': 66.5.0
-      '@unocss/vite': 66.0.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/preset-mini': 66.5.1
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
-  '@uni-helper/vite-plugin-uni-components@0.2.0(rollup@4.50.0)':
+  '@uni-helper/vite-plugin-uni-components@0.2.0(rollup@4.50.1)':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
       chokidar: 3.6.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       local-pkg: 0.4.3
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       minimatch: 8.0.4
       resolve: 1.22.10
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@uni-helper/vite-plugin-uni-manifest@0.2.8(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))':
+  '@uni-helper/vite-plugin-uni-manifest@0.2.8(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       c12: 2.0.4
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - magicast
 
-  '@uni-helper/vite-plugin-uni-pages@0.3.9(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))':
+  '@uni-helper/vite-plugin-uni-pages@0.3.11(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       '@babel/generator': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
       '@uni-helper/uni-env': 0.1.8
       '@vue/compiler-sfc': 3.4.21
-      ast-kit: 2.1.2
+      ast-kit: 1.4.3
       chokidar: 3.6.0
       comment-json: 4.2.5
-      debug: 4.4.1
+      debug: 4.4.3
       detect-indent: 6.1.0
       detect-newline: 3.1.0
       fast-glob: 3.3.3
       json5: 2.2.3
       kolorist: 1.8.0
       lodash.groupby: 4.6.0
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       typescript: 5.9.2
       unconfig: 7.3.3
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
       yaml: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
   '@unocss-applet/preset-applet@0.11.0':
     dependencies:
-      '@unocss/core': 66.5.0
-      '@unocss/preset-mini': 66.5.0
-      '@unocss/preset-wind3': 66.5.0
-      '@unocss/preset-wind4': 66.5.0
+      '@unocss/core': 66.5.1
+      '@unocss/preset-mini': 66.5.1
+      '@unocss/preset-wind3': 66.5.1
+      '@unocss/preset-wind4': 66.5.1
 
   '@unocss-applet/preset-rem-rpx@0.11.0':
     dependencies:
-      '@unocss/core': 66.5.0
+      '@unocss/core': 66.5.1
 
   '@unocss-applet/transformer-attributify@0.11.0':
     dependencies:
-      '@unocss/core': 66.5.0
-      magic-string: 0.30.18
+      '@unocss/core': 66.5.1
+      magic-string: 0.30.19
 
-  '@unocss/astro@66.0.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@unocss/astro@66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@unocss/core': 66.0.0
       '@unocss/reset': 66.0.0
-      '@unocss/vite': 66.0.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
     optionalDependencies:
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - vue
 
@@ -10016,10 +10066,10 @@ snapshots:
       chokidar: 3.6.0
       colorette: 2.0.20
       consola: 3.4.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       pathe: 2.0.3
       perfect-debounce: 1.0.0
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       unplugin-utils: 0.2.5
 
   '@unocss/config@66.0.0':
@@ -10029,15 +10079,15 @@ snapshots:
 
   '@unocss/core@66.0.0': {}
 
-  '@unocss/core@66.5.0': {}
+  '@unocss/core@66.5.1': {}
 
   '@unocss/extractor-arbitrary-variants@66.0.0':
     dependencies:
       '@unocss/core': 66.0.0
 
-  '@unocss/extractor-arbitrary-variants@66.5.0':
+  '@unocss/extractor-arbitrary-variants@66.5.1':
     dependencies:
-      '@unocss/core': 66.5.0
+      '@unocss/core': 66.5.1
 
   '@unocss/inspector@66.0.0(vue@3.4.38(typescript@5.9.2))':
     dependencies:
@@ -10045,7 +10095,7 @@ snapshots:
       '@unocss/rule-utils': 66.0.0
       colorette: 2.0.20
       gzip-size: 6.0.0
-      sirv: 3.0.1
+      sirv: 3.0.2
       vue-flow-layout: 0.1.1(vue@3.4.38(typescript@5.9.2))
     transitivePeerDependencies:
       - vue
@@ -10057,7 +10107,7 @@ snapshots:
       '@unocss/rule-utils': 66.0.0
       css-tree: 3.1.0
       postcss: 8.5.6
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
 
   '@unocss/preset-attributify@66.0.0':
     dependencies:
@@ -10071,9 +10121,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@unocss/preset-legacy-compat@66.5.0':
+  '@unocss/preset-legacy-compat@66.5.1':
     dependencies:
-      '@unocss/core': 66.5.0
+      '@unocss/core': 66.5.1
 
   '@unocss/preset-mini@66.0.0':
     dependencies:
@@ -10081,11 +10131,11 @@ snapshots:
       '@unocss/extractor-arbitrary-variants': 66.0.0
       '@unocss/rule-utils': 66.0.0
 
-  '@unocss/preset-mini@66.5.0':
+  '@unocss/preset-mini@66.5.1':
     dependencies:
-      '@unocss/core': 66.5.0
-      '@unocss/extractor-arbitrary-variants': 66.5.0
-      '@unocss/rule-utils': 66.5.0
+      '@unocss/core': 66.5.1
+      '@unocss/extractor-arbitrary-variants': 66.5.1
+      '@unocss/rule-utils': 66.5.1
 
   '@unocss/preset-tagify@66.0.0':
     dependencies:
@@ -10113,17 +10163,17 @@ snapshots:
       '@unocss/preset-mini': 66.0.0
       '@unocss/rule-utils': 66.0.0
 
-  '@unocss/preset-wind3@66.5.0':
+  '@unocss/preset-wind3@66.5.1':
     dependencies:
-      '@unocss/core': 66.5.0
-      '@unocss/preset-mini': 66.5.0
-      '@unocss/rule-utils': 66.5.0
+      '@unocss/core': 66.5.1
+      '@unocss/preset-mini': 66.5.1
+      '@unocss/rule-utils': 66.5.1
 
-  '@unocss/preset-wind4@66.5.0':
+  '@unocss/preset-wind4@66.5.1':
     dependencies:
-      '@unocss/core': 66.5.0
-      '@unocss/extractor-arbitrary-variants': 66.5.0
-      '@unocss/rule-utils': 66.5.0
+      '@unocss/core': 66.5.1
+      '@unocss/extractor-arbitrary-variants': 66.5.1
+      '@unocss/rule-utils': 66.5.1
 
   '@unocss/preset-wind@66.0.0':
     dependencies:
@@ -10135,12 +10185,12 @@ snapshots:
   '@unocss/rule-utils@66.0.0':
     dependencies:
       '@unocss/core': 66.0.0
-      magic-string: 0.30.18
+      magic-string: 0.30.19
 
-  '@unocss/rule-utils@66.5.0':
+  '@unocss/rule-utils@66.5.1':
     dependencies:
-      '@unocss/core': 66.5.0
-      magic-string: 0.30.18
+      '@unocss/core': 66.5.1
+      magic-string: 0.30.19
 
   '@unocss/transformer-attributify-jsx@66.0.0':
     dependencies:
@@ -10160,63 +10210,63 @@ snapshots:
     dependencies:
       '@unocss/core': 66.0.0
 
-  '@unocss/vite@66.0.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.0.0
       '@unocss/core': 66.0.0
       '@unocss/inspector': 66.0.0(vue@3.4.38(typescript@5.9.2))
       chokidar: 3.6.0
-      magic-string: 0.30.18
-      tinyglobby: 0.2.14
+      magic-string: 0.30.19
+      tinyglobby: 0.2.15
       unplugin-utils: 0.2.5
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - vue
 
-  '@vitejs/plugin-legacy@5.3.2(terser@5.44.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))':
+  '@vitejs/plugin-legacy@5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
-      browserslist: 4.25.4
-      browserslist-to-esbuild: 2.1.1(browserslist@4.25.4)
+      '@babel/core': 7.28.4
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.4)
+      browserslist: 4.26.0
+      browserslist-to-esbuild: 2.1.1(browserslist@4.26.0)
       core-js: 3.45.1
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       regenerator-runtime: 0.14.1
       systemjs: 6.15.1
       terser: 5.44.0
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.3)
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.3)
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      '@babel/core': 7.28.4
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
-  '@vitest/eslint-plugin@1.3.7(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jsdom@16.7.0)(terser@5.44.0))':
+  '@vitest/eslint-plugin@1.3.9(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0))':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.42.0
-      '@typescript-eslint/utils': 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      eslint: 9.34.0(jiti@2.5.1)
+      '@typescript-eslint/scope-manager': 8.43.0
+      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint: 9.35.0(jiti@2.5.1)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jsdom@16.7.0)(terser@5.44.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10228,13 +10278,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.19(@types/node@24.3.0)(terser@5.44.0))':
+  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@24.3.3)(terser@5.44.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.18
+      magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10249,7 +10299,7 @@ snapshots:
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       pathe: 2.0.3
 
   '@vitest/spy@3.2.4':
@@ -10276,36 +10326,36 @@ snapshots:
 
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
-  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.28.3)':
+  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.28.4)':
     dependencies:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
       '@vue/babel-helper-vue-transform-on': 1.5.0
-      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.28.3)
+      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.28.4)
       '@vue/shared': 3.5.21
     optionalDependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.28.3)':
+  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.28.4)':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/compiler-sfc': 3.5.21
     transitivePeerDependencies:
       - supports-color
 
   '@vue/compiler-core@3.4.21':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/shared': 3.4.21
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -10313,7 +10363,7 @@ snapshots:
 
   '@vue/compiler-core@3.4.38':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/shared': 3.4.38
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -10321,7 +10371,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.21':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/shared': 3.5.21
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -10344,37 +10394,37 @@ snapshots:
 
   '@vue/compiler-sfc@3.4.21':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-ssr': 3.4.21
       '@vue/shared': 3.4.21
       estree-walker: 2.0.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       postcss: 8.5.6
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.4.38':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/compiler-core': 3.4.38
       '@vue/compiler-dom': 3.4.38
       '@vue/compiler-ssr': 3.4.38
       '@vue/shared': 3.4.38
       estree-walker: 2.0.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       postcss: 8.5.6
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.21':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/compiler-core': 3.5.21
       '@vue/compiler-dom': 3.5.21
       '@vue/compiler-ssr': 3.5.21
       '@vue/shared': 3.5.21
       estree-walker: 2.0.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       postcss: 8.5.6
       source-map-js: 1.2.1
 
@@ -10501,44 +10551,44 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@xiaohe01/eslint-config@2.2.2(@vue/compiler-sfc@3.5.21)(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jsdom@16.7.0)(terser@5.44.0))':
+  '@xiaohe01/eslint-config@2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
-      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.34.0(jiti@2.5.1))
+      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.35.0(jiti@2.5.1))
       '@eslint/markdown': 7.2.0
-      '@stylistic/eslint-plugin': 5.3.1(eslint@9.34.0(jiti@2.5.1))
-      '@typescript-eslint/eslint-plugin': 8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      '@vitest/eslint-plugin': 1.3.7(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jsdom@16.7.0)(terser@5.44.0))
+      '@stylistic/eslint-plugin': 5.3.1(eslint@9.35.0(jiti@2.5.1))
+      '@typescript-eslint/eslint-plugin': 8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@vitest/eslint-plugin': 1.3.9(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0))
       ansis: 4.1.0
       cac: 6.7.14
-      eslint: 9.34.0(jiti@2.5.1)
-      eslint-config-flat-gitignore: 2.1.0(eslint@9.34.0(jiti@2.5.1))
+      eslint: 9.35.0(jiti@2.5.1)
+      eslint-config-flat-gitignore: 2.1.0(eslint@9.35.0(jiti@2.5.1))
       eslint-flat-config-utils: 2.1.1
-      eslint-merge-processors: 2.0.0(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-antfu: 3.1.1(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-command: 3.3.1(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-import-lite: 0.3.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      eslint-plugin-jsdoc: 52.0.4(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-jsonc: 2.20.1(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-n: 17.21.3(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint-merge-processors: 2.0.0(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-antfu: 3.1.1(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-command: 3.3.1(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-import-lite: 0.3.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint-plugin-jsdoc: 54.7.0(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-jsonc: 2.20.1(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-n: 17.22.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 4.15.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      eslint-plugin-pnpm: 1.1.1(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-regexp: 2.10.0(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-toml: 0.12.0(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-unicorn: 60.0.0(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.34.0(jiti@2.5.1)))
-      eslint-plugin-yml: 1.18.0(eslint@9.34.0(jiti@2.5.1))
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.34.0(jiti@2.5.1))
-      globals: 16.3.0
+      eslint-plugin-perfectionist: 4.15.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint-plugin-pnpm: 1.1.1(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-regexp: 2.10.0(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-toml: 0.12.0(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-unicorn: 61.0.2(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1)))
+      eslint-plugin-yml: 1.18.0(eslint@9.35.0(jiti@2.5.1))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))
+      globals: 16.4.0
       jsonc-eslint-parser: 2.4.0
       local-pkg: 1.1.2
       parse-gitignore: 2.0.0
       toml-eslint-parser: 0.10.0
-      vue-eslint-parser: 10.2.0(eslint@9.34.0(jiti@2.5.1))
+      vue-eslint-parser: 10.2.0(eslint@9.35.0(jiti@2.5.1))
       yaml-eslint-parser: 1.3.0
     transitivePeerDependencies:
       - '@eslint/json'
@@ -10547,15 +10597,15 @@ snapshots:
       - typescript
       - vitest
 
-  '@xiaohe01/stylelint-config@2.4.0(postcss@8.5.6)(stylelint@16.23.1(typescript@5.8.3))':
+  '@xiaohe01/stylelint-config@2.4.0(postcss@8.5.6)(stylelint@16.24.0(typescript@5.8.3))':
     dependencies:
       local-pkg: 1.1.2
       postcss-html: 1.8.0
       postcss-scss: 4.0.9(postcss@8.5.6)
-      stylelint: 16.23.1(typescript@5.8.3)
-      stylelint-config-recess-order: 7.2.0(stylelint-order@7.0.0(stylelint@16.23.1(typescript@5.8.3)))(stylelint@16.23.1(typescript@5.8.3))
-      stylelint-order: 7.0.0(stylelint@16.23.1(typescript@5.8.3))
-      stylelint-scss: 6.12.1(stylelint@16.23.1(typescript@5.8.3))
+      stylelint: 16.24.0(typescript@5.8.3)
+      stylelint-config-recess-order: 7.3.0(stylelint-order@7.0.0(stylelint@16.24.0(typescript@5.8.3)))(stylelint@16.24.0(typescript@5.8.3))
+      stylelint-order: 7.0.0(stylelint@16.24.0(typescript@5.8.3))
+      stylelint-scss: 6.12.1(stylelint@16.24.0(typescript@5.8.3))
     transitivePeerDependencies:
       - postcss
 
@@ -10589,7 +10639,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10630,13 +10680,13 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
-  ansi-escapes@7.0.0:
+  ansi-escapes@7.1.0:
     dependencies:
       environment: 1.1.0
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.0: {}
+  ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -10644,7 +10694,7 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  ansi-styles@6.2.1: {}
+  ansi-styles@6.2.3: {}
 
   ansis@4.1.0: {}
 
@@ -10673,9 +10723,9 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-kit@2.1.2:
+  ast-kit@1.4.3:
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       pathe: 2.0.3
 
   astral-regex@2.0.0: {}
@@ -10684,22 +10734,22 @@ snapshots:
 
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
-      caniuse-lite: 1.0.30001739
+      browserslist: 4.26.0
+      caniuse-lite: 1.0.30001741
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  babel-jest@27.5.1(@babel/core@7.28.3):
+  babel-jest@27.5.1(@babel/core@7.28.4):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1(@babel/core@7.28.3)
+      babel-preset-jest: 27.5.1(@babel/core@7.28.4)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -10719,58 +10769,58 @@ snapshots:
   babel-plugin-jest-hoist@27.5.1:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.3):
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.4):
     dependencies:
-      '@babel/compat-data': 7.28.0
-      '@babel/core': 7.28.3
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.3)
+      '@babel/compat-data': 7.28.4
+      '@babel/core': 7.28.4
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.4)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.3):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.28.4):
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.4)
       core-js-compat: 3.45.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.3):
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.28.4):
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.3):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.4):
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.3)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.3)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.3)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.3)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.3)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.3)
+      '@babel/core': 7.28.4
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.4)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.4)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
 
-  babel-preset-jest@27.5.1(@babel/core@7.28.3):
+  babel-preset-jest@27.5.1(@babel/core@7.28.4):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.3)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
 
   bail@2.0.2: {}
 
@@ -10781,6 +10831,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   base64url@3.0.1: {}
+
+  baseline-browser-mapping@2.8.3: {}
 
   binary-extensions@2.3.0: {}
 
@@ -10822,17 +10874,18 @@ snapshots:
 
   browser-process-hrtime@1.0.0: {}
 
-  browserslist-to-esbuild@2.1.1(browserslist@4.25.4):
+  browserslist-to-esbuild@2.1.1(browserslist@4.26.0):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       meow: 13.2.0
 
-  browserslist@4.25.4:
+  browserslist@4.26.0:
     dependencies:
-      caniuse-lite: 1.0.30001739
-      electron-to-chromium: 1.5.213
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.4)
+      baseline-browser-mapping: 2.8.3
+      caniuse-lite: 1.0.30001741
+      electron-to-chromium: 1.5.218
+      node-releases: 2.0.21
+      update-browserslist-db: 1.1.3(browserslist@4.26.0)
 
   bser@2.1.1:
     dependencies:
@@ -10860,12 +10913,14 @@ snapshots:
       package-manager-detector: 1.3.0
       semver: 7.7.2
       tinyexec: 1.0.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       yaml: 2.8.1
     transitivePeerDependencies:
       - magicast
 
-  byte-size@9.0.1: {}
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
 
   bytes@3.1.2: {}
 
@@ -10906,7 +10961,7 @@ snapshots:
   cacheable@1.10.4:
     dependencies:
       hookified: 1.12.0
-      keyv: 5.5.0
+      keyv: 5.5.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -10926,12 +10981,12 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.25.4
-      caniuse-lite: 1.0.30001739
+      browserslist: 4.26.0
+      caniuse-lite: 1.0.30001741
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001739: {}
+  caniuse-lite@1.0.30001741: {}
 
   ccount@2.0.1: {}
 
@@ -10954,7 +11009,7 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.6.0: {}
+  chalk@5.6.2: {}
 
   change-case@5.4.4: {}
 
@@ -11043,7 +11098,7 @@ snapshots:
 
   commander@11.1.0: {}
 
-  commander@14.0.0: {}
+  commander@14.0.1: {}
 
   commander@2.20.3: {}
 
@@ -11089,7 +11144,7 @@ snapshots:
 
   core-js-compat@3.45.1:
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
 
   core-js@3.45.1: {}
 
@@ -11156,7 +11211,7 @@ snapshots:
 
   cssnano-preset-default@7.0.9(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       css-declaration-sorter: 7.2.0(postcss@8.5.6)
       cssnano-utils: 5.0.1(postcss@8.5.6)
       postcss: 8.5.6
@@ -11224,7 +11279,7 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
-  debug@4.4.1:
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -11242,9 +11297,18 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.0: {}
+
+  default-browser@5.2.1:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.0
+
   default-gateway@6.0.3:
     dependencies:
       execa: 5.1.1
+
+  define-lazy-prop@3.0.0: {}
 
   defu@6.1.4: {}
 
@@ -11319,7 +11383,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.213: {}
+  electron-to-chromium@1.5.218: {}
 
   emittery@0.8.1: {}
 
@@ -11351,6 +11415,8 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser-es@0.1.5: {}
 
   es-define-property@1.0.1: {}
 
@@ -11470,67 +11536,67 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.34.0(jiti@2.5.1)):
+  eslint-compat-utils@0.5.1(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       semver: 7.7.2
 
-  eslint-compat-utils@0.6.5(eslint@9.34.0(jiti@2.5.1)):
+  eslint-compat-utils@0.6.5(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       semver: 7.7.2
 
-  eslint-config-flat-gitignore@2.1.0(eslint@9.34.0(jiti@2.5.1)):
+  eslint-config-flat-gitignore@2.1.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      '@eslint/compat': 1.3.2(eslint@9.34.0(jiti@2.5.1))
-      eslint: 9.34.0(jiti@2.5.1)
+      '@eslint/compat': 1.3.2(eslint@9.35.0(jiti@2.5.1))
+      eslint: 9.35.0(jiti@2.5.1)
 
   eslint-flat-config-utils@2.1.1:
     dependencies:
       pathe: 2.0.3
 
-  eslint-json-compat-utils@0.2.1(eslint@9.34.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0):
+  eslint-json-compat-utils@0.2.1(eslint@9.35.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0):
     dependencies:
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       esquery: 1.6.0
       jsonc-eslint-parser: 2.4.0
 
-  eslint-merge-processors@2.0.0(eslint@9.34.0(jiti@2.5.1)):
+  eslint-merge-processors@2.0.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
 
-  eslint-plugin-antfu@3.1.1(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-antfu@3.1.1(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
 
-  eslint-plugin-command@3.3.1(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-command@3.3.1(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       '@es-joy/jsdoccomment': 0.50.2
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
 
-  eslint-plugin-es-x@7.8.0(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-es-x@7.8.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
-      eslint: 9.34.0(jiti@2.5.1)
-      eslint-compat-utils: 0.5.1(eslint@9.34.0(jiti@2.5.1))
+      eslint: 9.35.0(jiti@2.5.1)
+      eslint-compat-utils: 0.5.1(eslint@9.35.0(jiti@2.5.1))
 
-  eslint-plugin-import-lite@0.3.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3):
+  eslint-plugin-import-lite@0.3.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
-      '@typescript-eslint/types': 8.42.0
-      eslint: 9.34.0(jiti@2.5.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      '@typescript-eslint/types': 8.43.0
+      eslint: 9.35.0(jiti@2.5.1)
     optionalDependencies:
       typescript: 5.8.3
 
-  eslint-plugin-jsdoc@52.0.4(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-jsdoc@54.7.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      '@es-joy/jsdoccomment': 0.52.0
+      '@es-joy/jsdoccomment': 0.56.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       espree: 10.4.0
       esquery: 1.6.0
       parse-imports-exports: 0.2.4
@@ -11539,12 +11605,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsonc@2.20.1(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-jsonc@2.20.1(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
-      eslint: 9.34.0(jiti@2.5.1)
-      eslint-compat-utils: 0.6.5(eslint@9.34.0(jiti@2.5.1))
-      eslint-json-compat-utils: 0.2.1(eslint@9.34.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      eslint: 9.35.0(jiti@2.5.1)
+      eslint-compat-utils: 0.6.5(eslint@9.35.0(jiti@2.5.1))
+      eslint-json-compat-utils: 0.2.1(eslint@9.35.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0)
       espree: 10.4.0
       graphemer: 1.4.0
       jsonc-eslint-parser: 2.4.0
@@ -11553,12 +11619,12 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@17.21.3(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3):
+  eslint-plugin-n@17.22.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
       enhanced-resolve: 5.18.3
-      eslint: 9.34.0(jiti@2.5.1)
-      eslint-plugin-es-x: 7.8.0(eslint@9.34.0(jiti@2.5.1))
+      eslint: 9.35.0(jiti@2.5.1)
+      eslint-plugin-es-x: 7.8.0(eslint@9.35.0(jiti@2.5.1))
       get-tsconfig: 4.10.1
       globals: 15.15.0
       globrex: 0.1.2
@@ -11570,60 +11636,60 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-perfectionist@4.15.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3):
+  eslint-plugin-perfectionist@4.15.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/types': 8.42.0
-      '@typescript-eslint/utils': 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
-      eslint: 9.34.0(jiti@2.5.1)
+      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint: 9.35.0(jiti@2.5.1)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-pnpm@1.1.1(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-pnpm@1.1.1(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       empathic: 2.0.0
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       jsonc-eslint-parser: 2.4.0
       pathe: 2.0.3
       pnpm-workspace-yaml: 1.1.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       yaml-eslint-parser: 1.3.0
 
-  eslint-plugin-regexp@2.10.0(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-regexp@2.10.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
       comment-parser: 1.4.1
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       jsdoc-type-pratt-parser: 4.8.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-toml@0.12.0(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-toml@0.12.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      debug: 4.4.1
-      eslint: 9.34.0(jiti@2.5.1)
-      eslint-compat-utils: 0.6.5(eslint@9.34.0(jiti@2.5.1))
+      debug: 4.4.3
+      eslint: 9.35.0(jiti@2.5.1)
+      eslint-compat-utils: 0.6.5(eslint@9.35.0(jiti@2.5.1))
       lodash: 4.17.21
       toml-eslint-parser: 0.10.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@60.0.0(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-unicorn@61.0.2(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
       '@eslint/plugin-kit': 0.3.5
       change-case: 5.4.4
       ci-info: 4.3.0
       clean-regexp: 1.0.0
       core-js-compat: 3.45.1
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
       esquery: 1.6.0
       find-up-simple: 1.0.1
-      globals: 16.3.0
+      globals: 16.4.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
       jsesc: 3.1.0
@@ -11631,42 +11697,42 @@ snapshots:
       regexp-tree: 0.1.27
       regjsparser: 0.12.0
       semver: 7.7.2
-      strip-indent: 4.0.0
+      strip-indent: 4.1.0
 
-  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
 
-  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.34.0(jiti@2.5.1))):
+  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
-      eslint: 9.34.0(jiti@2.5.1)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
+      eslint: 9.35.0(jiti@2.5.1)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.7.2
-      vue-eslint-parser: 10.2.0(eslint@9.34.0(jiti@2.5.1))
+      vue-eslint-parser: 10.2.0(eslint@9.35.0(jiti@2.5.1))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
 
-  eslint-plugin-yml@1.18.0(eslint@9.34.0(jiti@2.5.1)):
+  eslint-plugin-yml@1.18.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint: 9.34.0(jiti@2.5.1)
-      eslint-compat-utils: 0.6.5(eslint@9.34.0(jiti@2.5.1))
+      eslint: 9.35.0(jiti@2.5.1)
+      eslint-compat-utils: 0.6.5(eslint@9.35.0(jiti@2.5.1))
       natural-compare: 1.4.0
       yaml-eslint-parser: 1.3.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.34.0(jiti@2.5.1)):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       '@vue/compiler-sfc': 3.5.21
-      eslint: 9.34.0(jiti@2.5.1)
+      eslint: 9.35.0(jiti@2.5.1)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -11677,17 +11743,17 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.34.0(jiti@2.5.1):
+  eslint@9.35.0(jiti@2.5.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.34.0(jiti@2.5.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
       '@eslint/config-helpers': 0.3.1
       '@eslint/core': 0.15.2
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.34.0
+      '@eslint/js': 9.35.0
       '@eslint/plugin-kit': 0.3.5
-      '@humanfs/node': 0.16.6
+      '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
@@ -11695,7 +11761,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -11929,9 +11995,9 @@ snapshots:
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       mlly: 1.8.0
-      rollup: 4.50.0
+      rollup: 4.50.1
 
   flat-cache@4.0.1:
     dependencies:
@@ -12006,7 +12072,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.3.1: {}
+  get-east-asian-width@1.4.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -12105,7 +12171,7 @@ snapshots:
 
   globals@15.15.0: {}
 
-  globals@16.3.0: {}
+  globals@16.4.0: {}
 
   globby@11.1.0:
     dependencies:
@@ -12206,14 +12272,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12280,6 +12346,8 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-docker@3.0.0: {}
+
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
@@ -12290,7 +12358,7 @@ snapshots:
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
-      get-east-asian-width: 1.3.1
+      get-east-asian-width: 1.4.0
 
   is-function@1.0.2: {}
 
@@ -12299,6 +12367,10 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-module@1.0.0: {}
 
@@ -12324,6 +12396,10 @@ snapshots:
 
   is-what@4.1.16: {}
 
+  is-wsl@3.1.0:
+    dependencies:
+      is-inside-container: 1.0.0
+
   isbinaryfile@5.0.6: {}
 
   isexe@2.0.0: {}
@@ -12332,8 +12408,8 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.28.3
-      '@babel/parser': 7.28.3
+      '@babel/core': 7.28.4
+      '@babel/parser': 7.28.4
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -12348,7 +12424,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -12374,7 +12450,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -12416,10 +12492,10 @@ snapshots:
 
   jest-config@27.5.1:
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.28.3)
+      babel-jest: 27.5.1(@babel/core@7.28.4)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -12470,7 +12546,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -12485,7 +12561,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -12495,7 +12571,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12514,7 +12590,7 @@ snapshots:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -12557,7 +12633,7 @@ snapshots:
   jest-mock@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
 
   jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     optionalDependencies:
@@ -12593,7 +12669,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -12644,21 +12720,21 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.4
       '@babel/generator': 7.28.3
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.3)
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.28.0
       '@types/prettier': 2.7.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.3)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.4)
       chalk: 4.1.2
       expect: 27.5.1
       graceful-fs: 4.2.11
@@ -12677,7 +12753,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12696,7 +12772,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -12704,7 +12780,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -12722,7 +12798,7 @@ snapshots:
 
   jimp@0.10.3:
     dependencies:
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@jimp/custom': 0.10.3
       '@jimp/plugins': 0.10.3(@jimp/custom@0.10.3)
       '@jimp/types': 0.10.3(@jimp/custom@0.10.3)
@@ -12754,6 +12830,8 @@ snapshots:
 
   jsdoc-type-pratt-parser@4.8.0: {}
 
+  jsdoc-type-pratt-parser@5.1.1: {}
+
   jsdom@16.7.0:
     dependencies:
       abab: 2.0.6
@@ -12770,7 +12848,7 @@ snapshots:
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.21
+      nwsapi: 2.2.22
       parse5: 6.0.1
       saxes: 5.0.1
       symbol-tree: 3.2.4
@@ -12823,9 +12901,9 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  keyv@5.5.0:
+  keyv@5.5.1:
     dependencies:
-      '@keyv/serialize': 1.1.0
+      '@keyv/serialize': 1.1.1
 
   kind-of@6.0.3: {}
 
@@ -12866,13 +12944,13 @@ snapshots:
 
   lint-staged@16.1.6:
     dependencies:
-      chalk: 5.6.0
-      commander: 14.0.0
-      debug: 4.4.1
+      chalk: 5.6.2
+      commander: 14.0.1
+      debug: 4.4.3
       lilconfig: 3.1.3
       listr2: 9.0.3
       micromatch: 4.0.8
-      nano-spawn: 1.0.2
+      nano-spawn: 1.0.3
       pidtree: 0.6.0
       string-argv: 0.3.2
       yaml: 2.8.1
@@ -12886,7 +12964,7 @@ snapshots:
       eventemitter3: 5.0.1
       log-update: 6.1.0
       rfdc: 1.4.1
-      wrap-ansi: 9.0.0
+      wrap-ansi: 9.0.2
 
   load-bmfont@1.4.2:
     dependencies:
@@ -12945,23 +13023,23 @@ snapshots:
 
   log-update@6.1.0:
     dependencies:
-      ansi-escapes: 7.0.0
+      ansi-escapes: 7.1.0
       cli-cursor: 5.0.0
-      slice-ansi: 7.1.0
-      strip-ansi: 7.1.0
-      wrap-ansi: 9.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
 
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
 
-  lru-cache@11.1.0: {}
+  lru-cache@11.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
-  magic-string@0.30.18:
+  magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -13318,7 +13396,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1
+      debug: 4.4.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -13364,8 +13442,6 @@ snapshots:
     dependencies:
       dom-walk: 0.1.2
 
-  min-indent@1.0.1: {}
-
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
@@ -13409,7 +13485,7 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mkdist@2.3.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
+  mkdist@2.4.1(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.6)
       citty: 0.1.6
@@ -13423,7 +13499,7 @@ snapshots:
       postcss: 8.5.6
       postcss-nested: 7.0.2(postcss@8.5.6)
       semver: 7.7.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
     optionalDependencies:
       typescript: 5.8.3
       vue: 3.4.38(typescript@5.8.3)
@@ -13446,7 +13522,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nano-spawn@1.0.2: {}
+  nano-spawn@1.0.3: {}
 
   nanoid@3.3.11: {}
 
@@ -13460,7 +13536,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.19: {}
+  node-releases@2.0.21: {}
 
   normalize-path@3.0.0: {}
 
@@ -13479,7 +13555,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nwsapi@2.2.21: {}
+  nwsapi@2.2.22: {}
 
   nypm@0.5.4:
     dependencies:
@@ -13531,6 +13607,13 @@ snapshots:
       emoji-regex-xs: 1.0.0
       regex: 6.0.1
       regex-recursion: 6.0.2
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.2.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -13639,7 +13722,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.1.0
+      lru-cache: 11.2.1
       minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}
@@ -13704,7 +13787,7 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  pncat@0.5.3:
+  pncat@0.5.4:
     dependencies:
       '@clack/prompts': 0.11.0
       ansis: 4.1.0
@@ -13718,7 +13801,7 @@ snapshots:
       pkg-types: 2.3.0
       pnpm-workspace-yaml: 1.1.1
       semver: 7.7.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       unconfig: 7.3.3
 
   pngjs@3.4.0: {}
@@ -13735,7 +13818,7 @@ snapshots:
 
   postcss-colormin@7.0.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.6
@@ -13743,7 +13826,7 @@ snapshots:
 
   postcss-convert-values@7.0.7(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
@@ -13795,7 +13878,7 @@ snapshots:
 
   postcss-merge-rules@7.0.6(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       caniuse-api: 3.0.0
       cssnano-utils: 5.0.1(postcss@8.5.6)
       postcss: 8.5.6
@@ -13815,7 +13898,7 @@ snapshots:
 
   postcss-minify-params@7.0.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       cssnano-utils: 5.0.1(postcss@8.5.6)
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
@@ -13895,7 +13978,7 @@ snapshots:
 
   postcss-normalize-unicode@7.0.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
@@ -13917,7 +14000,7 @@ snapshots:
 
   postcss-reduce-initial@7.0.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       caniuse-api: 3.0.0
       postcss: 8.5.6
 
@@ -13973,11 +14056,11 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact@10.27.1: {}
+  preact@10.27.2: {}
 
   prelude-ls@1.2.1: {}
 
-  pretty-bytes@6.1.1: {}
+  pretty-bytes@7.0.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -14055,7 +14138,7 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.1
 
-  regenerate-unicode-properties@10.2.0:
+  regenerate-unicode-properties@10.2.2:
     dependencies:
       regenerate: 1.4.2
 
@@ -14082,14 +14165,14 @@ snapshots:
 
   regexp-tree@0.1.27: {}
 
-  regexpu-core@6.2.0:
+  regexpu-core@6.3.1:
     dependencies:
       regenerate: 1.4.2
-      regenerate-unicode-properties: 10.2.0
+      regenerate-unicode-properties: 10.2.2
       regjsgen: 0.8.0
       regjsparser: 0.12.0
       unicode-match-property-ecmascript: 2.0.0
-      unicode-match-property-value-ecmascript: 2.2.0
+      unicode-match-property-value-ecmascript: 2.2.1
 
   regjsgen@0.8.0: {}
 
@@ -14174,40 +14257,42 @@ snapshots:
       glob: 11.0.3
       package-json-from-dist: 1.0.1
 
-  rollup-plugin-dts@6.2.3(rollup@4.50.0)(typescript@5.8.3):
+  rollup-plugin-dts@6.2.3(rollup@4.50.1)(typescript@5.8.3):
     dependencies:
-      magic-string: 0.30.18
-      rollup: 4.50.0
+      magic-string: 0.30.19
+      rollup: 4.50.1
       typescript: 5.8.3
     optionalDependencies:
       '@babel/code-frame': 7.27.1
 
-  rollup@4.50.0:
+  rollup@4.50.1:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.50.0
-      '@rollup/rollup-android-arm64': 4.50.0
-      '@rollup/rollup-darwin-arm64': 4.50.0
-      '@rollup/rollup-darwin-x64': 4.50.0
-      '@rollup/rollup-freebsd-arm64': 4.50.0
-      '@rollup/rollup-freebsd-x64': 4.50.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.50.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.50.0
-      '@rollup/rollup-linux-arm64-gnu': 4.50.0
-      '@rollup/rollup-linux-arm64-musl': 4.50.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.50.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.50.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.50.0
-      '@rollup/rollup-linux-riscv64-musl': 4.50.0
-      '@rollup/rollup-linux-s390x-gnu': 4.50.0
-      '@rollup/rollup-linux-x64-gnu': 4.50.0
-      '@rollup/rollup-linux-x64-musl': 4.50.0
-      '@rollup/rollup-openharmony-arm64': 4.50.0
-      '@rollup/rollup-win32-arm64-msvc': 4.50.0
-      '@rollup/rollup-win32-ia32-msvc': 4.50.0
-      '@rollup/rollup-win32-x64-msvc': 4.50.0
+      '@rollup/rollup-android-arm-eabi': 4.50.1
+      '@rollup/rollup-android-arm64': 4.50.1
+      '@rollup/rollup-darwin-arm64': 4.50.1
+      '@rollup/rollup-darwin-x64': 4.50.1
+      '@rollup/rollup-freebsd-arm64': 4.50.1
+      '@rollup/rollup-freebsd-x64': 4.50.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.50.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.50.1
+      '@rollup/rollup-linux-arm64-gnu': 4.50.1
+      '@rollup/rollup-linux-arm64-musl': 4.50.1
+      '@rollup/rollup-linux-loongarch64-gnu': 4.50.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.50.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.50.1
+      '@rollup/rollup-linux-riscv64-musl': 4.50.1
+      '@rollup/rollup-linux-s390x-gnu': 4.50.1
+      '@rollup/rollup-linux-x64-gnu': 4.50.1
+      '@rollup/rollup-linux-x64-musl': 4.50.1
+      '@rollup/rollup-openharmony-arm64': 4.50.1
+      '@rollup/rollup-win32-arm64-msvc': 4.50.1
+      '@rollup/rollup-win32-ia32-msvc': 4.50.1
+      '@rollup/rollup-win32-x64-msvc': 4.50.1
       fsevents: 2.3.3
+
+  run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -14332,7 +14417,7 @@ snapshots:
 
   simple-git-hooks@2.13.1: {}
 
-  sirv@3.0.1:
+  sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
@@ -14350,12 +14435,12 @@ snapshots:
 
   slice-ansi@5.0.0:
     dependencies:
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
-  slice-ansi@7.1.0:
+  slice-ansi@7.1.2:
     dependencies:
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
   source-map-js@1.2.1: {}
@@ -14413,13 +14498,13 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
+      strip-ansi: 7.1.2
 
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.5.0
-      get-east-asian-width: 1.3.1
-      strip-ansi: 7.1.0
+      get-east-asian-width: 1.4.0
+      strip-ansi: 7.1.2
 
   stringify-entities@4.0.4:
     dependencies:
@@ -14430,9 +14515,9 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.1.0:
+  strip-ansi@7.1.2:
     dependencies:
-      ansi-regex: 6.2.0
+      ansi-regex: 6.2.2
 
   strip-bom-string@1.0.0: {}
 
@@ -14442,9 +14527,7 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
-  strip-indent@4.0.0:
-    dependencies:
-      min-indent: 1.0.1
+  strip-indent@4.1.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -14454,22 +14537,22 @@ snapshots:
 
   stylehacks@7.0.6(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
-  stylelint-config-recess-order@7.2.0(stylelint-order@7.0.0(stylelint@16.23.1(typescript@5.8.3)))(stylelint@16.23.1(typescript@5.8.3)):
+  stylelint-config-recess-order@7.3.0(stylelint-order@7.0.0(stylelint@16.24.0(typescript@5.8.3)))(stylelint@16.24.0(typescript@5.8.3)):
     dependencies:
-      stylelint: 16.23.1(typescript@5.8.3)
-      stylelint-order: 7.0.0(stylelint@16.23.1(typescript@5.8.3))
+      stylelint: 16.24.0(typescript@5.8.3)
+      stylelint-order: 7.0.0(stylelint@16.24.0(typescript@5.8.3))
 
-  stylelint-order@7.0.0(stylelint@16.23.1(typescript@5.8.3)):
+  stylelint-order@7.0.0(stylelint@16.24.0(typescript@5.8.3)):
     dependencies:
       postcss: 8.5.6
       postcss-sorting: 9.1.0(postcss@8.5.6)
-      stylelint: 16.23.1(typescript@5.8.3)
+      stylelint: 16.24.0(typescript@5.8.3)
 
-  stylelint-scss@6.12.1(stylelint@16.23.1(typescript@5.8.3)):
+  stylelint-scss@6.12.1(stylelint@16.24.0(typescript@5.8.3)):
     dependencies:
       css-tree: 3.1.0
       is-plain-object: 5.0.0
@@ -14479,9 +14562,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
-      stylelint: 16.23.1(typescript@5.8.3)
+      stylelint: 16.24.0(typescript@5.8.3)
 
-  stylelint@16.23.1(typescript@5.8.3):
+  stylelint@16.24.0(typescript@5.8.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
@@ -14493,7 +14576,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       css-functions-list: 3.2.3
       css-tree: 3.1.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
       file-entry-cache: 10.1.4
@@ -14620,7 +14703,7 @@ snapshots:
 
   tinyexec@1.0.1: {}
 
-  tinyglobby@0.2.14:
+  tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
@@ -14705,14 +14788,14 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  unbuild@3.5.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
+  unbuild@3.6.1(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
     dependencies:
-      '@rollup/plugin-alias': 5.1.1(rollup@4.50.0)
-      '@rollup/plugin-commonjs': 28.0.6(rollup@4.50.0)
-      '@rollup/plugin-json': 6.1.0(rollup@4.50.0)
-      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.50.0)
-      '@rollup/plugin-replace': 6.0.2(rollup@4.50.0)
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.0)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.50.1)
+      '@rollup/plugin-commonjs': 28.0.6(rollup@4.50.1)
+      '@rollup/plugin-json': 6.1.0(rollup@4.50.1)
+      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.50.1)
+      '@rollup/plugin-replace': 6.0.2(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -14720,16 +14803,16 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       hookable: 5.5.3
       jiti: 2.5.1
-      magic-string: 0.30.18
-      mkdist: 2.3.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
+      magic-string: 0.30.19
+      mkdist: 2.4.1(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
-      pretty-bytes: 6.1.1
-      rollup: 4.50.0
-      rollup-plugin-dts: 6.2.3(rollup@4.50.0)(typescript@5.8.3)
+      pretty-bytes: 7.0.1
+      rollup: 4.50.1
+      rollup-plugin-dts: 6.2.3(rollup@4.50.1)(typescript@5.8.3)
       scule: 1.3.0
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       untyped: 2.0.0
     optionalDependencies:
       typescript: 5.8.3
@@ -14761,7 +14844,7 @@ snapshots:
       unicode-canonical-property-names-ecmascript: 2.0.1
       unicode-property-aliases-ecmascript: 2.1.0
 
-  unicode-match-property-value-ecmascript@2.2.0: {}
+  unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
 
@@ -14786,7 +14869,7 @@ snapshots:
       estree-walker: 3.0.3
       fast-glob: 3.3.3
       local-pkg: 1.1.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       mlly: 1.8.0
       pathe: 2.0.3
       picomatch: 4.0.3
@@ -14802,14 +14885,14 @@ snapshots:
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       local-pkg: 1.1.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       mlly: 1.8.0
       pathe: 2.0.3
       picomatch: 4.0.3
       pkg-types: 2.3.0
       scule: 1.3.0
       strip-literal: 3.0.0
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       unplugin: 2.3.10
       unplugin-utils: 0.2.5
 
@@ -14846,16 +14929,16 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))):
+  unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))):
     dependencies:
       '@unocss-applet/preset-applet': 0.11.0
       '@unocss-applet/preset-rem-rpx': 0.11.0
       '@unocss-applet/transformer-attributify': 0.11.0
-      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
-  unocss@66.0.0(postcss@8.5.6)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)):
+  unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)):
     dependencies:
-      '@unocss/astro': 66.0.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/astro': 66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@unocss/cli': 66.0.0
       '@unocss/core': 66.0.0
       '@unocss/postcss': 66.0.0(postcss@8.5.6)
@@ -14872,9 +14955,9 @@ snapshots:
       '@unocss/transformer-compile-class': 66.0.0
       '@unocss/transformer-directives': 66.0.0
       '@unocss/transformer-variant-group': 66.0.0
-      '@unocss/vite': 66.0.0(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
     optionalDependencies:
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -14885,7 +14968,7 @@ snapshots:
   unplugin-auto-import@19.1.0(@vueuse/core@12.8.2(typescript@5.9.2)):
     dependencies:
       local-pkg: 1.1.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       picomatch: 4.0.3
       unimport: 4.1.1
       unplugin: 2.3.10
@@ -14896,7 +14979,7 @@ snapshots:
   unplugin-auto-import@20.1.0(@vueuse/core@12.8.2(typescript@5.9.2)):
     dependencies:
       local-pkg: 1.1.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       picomatch: 4.0.3
       unimport: 5.2.0
       unplugin: 2.3.10
@@ -14931,9 +15014,9 @@ snapshots:
       knitwork: 1.2.0
       scule: 1.3.0
 
-  update-browserslist-db@1.1.3(browserslist@4.25.4):
+  update-browserslist-db@1.1.3(browserslist@4.26.0):
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.26.0
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -14972,13 +15055,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.3.0)(terser@5.44.0):
+  vite-node@3.2.4(@types/node@24.3.3)(terser@5.44.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -14990,32 +15073,47 @@ snapshots:
       - supports-color
       - terser
 
+  vite-plugin-inspect@0.8.9(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)):
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      debug: 4.4.3
+      error-stack-parser-es: 0.1.5
+      fs-extra: 11.3.1
+      open: 10.2.0
+      perfect-debounce: 1.0.0
+      picocolors: 1.1.1
+      sirv: 3.0.2
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   vite-plugin-uni-polyfill@0.1.0: {}
 
-  vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0):
+  vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
-      rollup: 4.50.0
+      rollup: 4.50.1
     optionalDependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       fsevents: 2.3.3
       sass: 1.78.0
       terser: 5.44.0
 
-  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)):
+  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)):
     dependencies:
       '@iconify-json/logos': 1.2.9
       '@iconify-json/vscode-icons': 1.2.30
       '@iconify/utils': 3.0.1
       markdown-it: 14.1.0
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
-  vitepress-plugin-llms@1.7.3:
+  vitepress-plugin-llms@1.7.5:
     dependencies:
-      byte-size: 9.0.1
       gray-matter: 4.0.3
       markdown-it: 14.1.0
       markdown-title: 1.0.2
@@ -15023,25 +15121,25 @@ snapshots:
       minimatch: 10.0.3
       path-to-regexp: 8.3.0
       picocolors: 1.1.1
+      pretty-bytes: 7.0.1
       remark: 15.0.1
       remark-frontmatter: 5.0.0
       tokenx: 1.1.0
       unist-util-remove: 4.0.0
       unist-util-visit: 5.0.0
     transitivePeerDependencies:
-      - '@75lb/nature'
       - supports-color
 
-  vitepress@1.6.4(@algolia/client-search@5.37.0)(@types/node@24.3.0)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2):
+  vitepress@1.6.4(@algolia/client-search@5.37.0)(@types/node@24.3.3)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.37.0)(search-insights@2.17.3)
-      '@iconify-json/simple-icons': 1.2.50
+      '@iconify-json/simple-icons': 1.2.51
       '@shikijs/core': 2.5.0
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.21
       '@vueuse/core': 12.8.2(typescript@5.9.2)
@@ -15050,7 +15148,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.2
       shiki: 2.5.0
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
     optionalDependencies:
       postcss: 8.5.6
@@ -15081,34 +15179,34 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jsdom@16.7.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.19(@types/node@24.3.0)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@24.3.3)(terser@5.44.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.2
-      magic-string: 0.30.18
+      magic-string: 0.30.19
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@24.3.0)(sass@1.78.0)(terser@5.44.0)
-      vite-node: 3.2.4(@types/node@24.3.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite-node: 3.2.4(@types/node@24.3.3)(terser@5.44.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.3.0
+      '@types/node': 24.3.3
       jsdom: 16.7.0
     transitivePeerDependencies:
       - less
@@ -15127,10 +15225,10 @@ snapshots:
     dependencies:
       vue: 3.4.38(typescript@5.9.2)
 
-  vue-eslint-parser@10.2.0(eslint@9.34.0(jiti@2.5.1)):
+  vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
-      debug: 4.4.1
-      eslint: 9.34.0(jiti@2.5.1)
+      debug: 4.4.3
+      eslint: 9.35.0(jiti@2.5.1)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -15232,15 +15330,15 @@ snapshots:
 
   wrap-ansi@8.1.0:
     dependencies:
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.1.0
+      strip-ansi: 7.1.2
 
-  wrap-ansi@9.0.0:
+  wrap-ansi@9.0.2:
     dependencies:
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       string-width: 7.2.0
-      strip-ansi: 7.1.0
+      strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
 
@@ -15259,6 +15357,10 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.18.3: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.0
 
   xhr@2.6.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ catalogs:
       specifier: ^9.36.0
       version: 9.36.0
     lint-staged:
-      specifier: ^16.1.6
-      version: 16.1.6
+      specifier: ^16.2.0
+      version: 16.2.0
     simple-git-hooks:
       specifier: ^2.13.1
       version: 2.13.1
@@ -215,9 +215,6 @@ catalogs:
     '@types/lodash-es':
       specifier: ^4.17.12
       version: 4.17.12
-    '@types/node':
-      specifier: ^22.18.6
-      version: 22.18.6
   utils:
     '@antfu/utils':
       specifier: ^9.2.1
@@ -230,6 +227,7 @@ catalogs:
       version: 4.17.21
 
 overrides:
+  '@types/node': 22.18.6
   mkdist: 2.3.0
   vue: 3.4.38
 
@@ -253,7 +251,7 @@ importers:
         specifier: catalog:types
         version: 11.0.4
       '@types/node':
-        specifier: catalog:types
+        specifier: 22.18.6
         version: 22.18.6
       '@uni-helper/uni-app-types':
         specifier: catalog:dev
@@ -290,7 +288,7 @@ importers:
         version: 11.3.2
       lint-staged:
         specifier: catalog:lint
-        version: 16.1.6
+        version: 16.2.0
       miniprogram-api-typings:
         specifier: catalog:dev
         version: 4.1.0
@@ -314,7 +312,7 @@ importers:
         version: 3.5.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
       vite:
         specifier: catalog:build
-        version: 5.4.20(@types/node@22.18.6)(terser@5.44.0)
+        version: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
       vitest:
         specifier: catalog:test
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0)
@@ -326,10 +324,10 @@ importers:
     devDependencies:
       vitepress:
         specifier: catalog:build
-        version: 1.6.4(@algolia/client-search@5.37.0)(@types/node@24.5.2)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2)
+        version: 1.6.4(@algolia/client-search@5.37.0)(@types/node@22.18.6)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2)
       vitepress-plugin-group-icons:
         specifier: catalog:build
-        version: 1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
+        version: 1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))
       vitepress-plugin-llms:
         specifier: catalog:build
         version: 1.7.5
@@ -374,10 +372,10 @@ importers:
         version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-harmony':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-plus':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-components':
         specifier: catalog:dcloudio
         version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
@@ -447,7 +445,7 @@ importers:
         version: 3.0.0-4070620250821001
       '@dcloudio/vite-plugin-uni':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@iconify-json/carbon':
         specifier: catalog:icons
         version: 1.2.13
@@ -456,19 +454,19 @@ importers:
         version: 4.17.12
       '@uni-helper/plugin-uni':
         specifier: catalog:dev
-        version: 0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       '@uni-helper/unocss-preset-uni':
         specifier: catalog:style
-        version: 0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       '@uni-helper/vite-plugin-uni-components':
         specifier: catalog:build
         version: 0.2.1(rollup@4.52.0)
       '@uni-helper/vite-plugin-uni-manifest':
         specifier: catalog:build
-        version: 0.2.8(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
+        version: 0.2.8(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))
       '@uni-helper/vite-plugin-uni-pages':
         specifier: catalog:build
-        version: 0.3.15(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
+        version: 0.3.15(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))
       '@vue/runtime-core':
         specifier: catalog:frontend
         version: 3.4.38
@@ -477,16 +475,16 @@ importers:
         version: 1.78.0
       unocss:
         specifier: catalog:style
-        version: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       unocss-applet:
         specifier: catalog:style
-        version: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       unplugin-auto-import:
         specifier: catalog:build
         version: 20.1.0(@vueuse/core@12.8.2(typescript@5.9.2))
       vite-plugin-inspect:
         specifier: catalog:build
-        version: 0.8.9(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
+        version: 0.8.9(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))
       vite-plugin-uni-polyfill:
         specifier: catalog:build
         version: 0.1.0
@@ -2606,9 +2604,6 @@ packages:
   '@types/node@22.18.6':
     resolution: {integrity: sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==}
 
-  '@types/node@24.5.2':
-    resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
-
   '@types/prettier@2.7.3':
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
 
@@ -4140,14 +4135,17 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
 
-  eslint-plugin-vue@10.4.0:
-    resolution: {integrity: sha512-K6tP0dW8FJVZLQxa2S7LcE1lLw3X8VvB3t887Q6CLrFVxHYBXGANbXvwNzYIu6Ughx1bSJ5BDT0YB3ybPT39lw==}
+  eslint-plugin-vue@10.5.0:
+    resolution: {integrity: sha512-7BZHsG3kC2vei8F2W8hnfDi9RK+cv5eKPMvzBdrl8Vuc0hR5odGQRli8VVzUkrmUHkxFEm4Iio1r5HOKslO0Aw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
+      '@stylistic/eslint-plugin': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
       '@typescript-eslint/parser': ^7.0.0 || ^8.0.0
       eslint: ^8.57.0 || ^9.0.0
       vue-eslint-parser: ^10.0.0
     peerDependenciesMeta:
+      '@stylistic/eslint-plugin':
+        optional: true
       '@typescript-eslint/parser':
         optional: true
 
@@ -5090,8 +5088,8 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
-  lint-staged@16.1.6:
-    resolution: {integrity: sha512-U4kuulU3CKIytlkLlaHcGgKscNfJPNTiDF2avIUGFCv7K95/DCYQ7Ra62ydeRWmgQGg9zJYw2dzdbztwJlqrow==}
+  lint-staged@16.2.0:
+    resolution: {integrity: sha512-spdYSOCQ2MdZ9CM1/bu/kDmaYGsrpNOeu1InFFV8uhv14x6YIubGxbCpSmGILFoxkiheNQPDXSg5Sbb5ZuVnug==}
     engines: {node: '>=20.17'}
     hasBin: true
 
@@ -6777,9 +6775,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici-types@7.12.0:
-    resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
-
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -6964,7 +6959,7 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': 22.18.6
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
@@ -7018,7 +7013,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': 22.18.6
       '@vitest/browser': 3.2.4
       '@vitest/ui': 3.2.4
       happy-dom: '*'
@@ -8208,10 +8203,10 @@ snapshots:
 
   '@dcloudio/types@3.4.21': {}
 
-  '@dcloudio/uni-app-harmony@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-harmony@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       debug: 4.4.3
       fs-extra: 10.1.0
       licia: 1.48.0
@@ -8226,10 +8221,10 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-plus@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-plus@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-vue': 3.0.0-4070620250821001
       debug: 4.4.3
       fs-extra: 10.1.0
@@ -8280,14 +8275,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-app-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-nvue-styler': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       debug: 4.4.3
@@ -8787,7 +8782,7 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
@@ -8795,9 +8790,9 @@ snapshots:
       '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
-      '@vitejs/plugin-legacy': 5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-legacy': 5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -8814,7 +8809,7 @@ snapshots:
       picocolors: 1.1.1
       terser: 5.44.0
       unplugin-auto-import: 19.1.0(@vueuse/core@12.8.2(typescript@5.9.2))
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -9284,7 +9279,7 @@ snapshots:
   '@jest/console@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -9297,7 +9292,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -9331,14 +9326,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       jest-mock: 27.5.1
 
   '@jest/fake-timers@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -9356,7 +9351,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -9425,7 +9420,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -10045,7 +10040,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   '@types/hast@3.0.4':
     dependencies:
@@ -10091,10 +10086,6 @@ snapshots:
   '@types/node@22.18.6':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/node@24.5.2':
-    dependencies:
-      undici-types: 7.12.0
 
   '@types/prettier@2.7.3': {}
 
@@ -10207,9 +10198,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@uni-helper/plugin-uni@0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
+  '@uni-helper/plugin-uni@0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
     dependencies:
-      '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
   '@uni-helper/uni-app-types@1.0.0-alpha.6(typescript@5.8.3)(vue@3.4.38(typescript@5.8.3))':
     dependencies:
@@ -10220,16 +10211,16 @@ snapshots:
     dependencies:
       std-env: 3.9.0
 
-  '@uni-helper/unocss-preset-uni@0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
+  '@uni-helper/unocss-preset-uni@0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
     dependencies:
       '@uni-helper/uni-env': 0.1.8
       '@unocss/preset-legacy-compat': 66.5.1
       '@unocss/rule-utils': 66.5.1
-      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      unocss-applet: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      unocss-applet: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
     optionalDependencies:
       '@unocss/preset-mini': 66.5.1
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
   '@uni-helper/vite-plugin-uni-components@0.2.1(rollup@4.52.0)':
     dependencies:
@@ -10246,14 +10237,14 @@ snapshots:
       - rollup
       - supports-color
 
-  '@uni-helper/vite-plugin-uni-manifest@0.2.8(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))':
+  '@uni-helper/vite-plugin-uni-manifest@0.2.8(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       c12: 2.0.4
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - magicast
 
-  '@uni-helper/vite-plugin-uni-pages@0.3.15(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))':
+  '@uni-helper/vite-plugin-uni-pages@0.3.15(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/types': 7.28.4
@@ -10272,7 +10263,7 @@ snapshots:
       magic-string: 0.30.19
       typescript: 5.9.2
       unconfig: 7.3.3
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
       yaml: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -10293,13 +10284,13 @@ snapshots:
       '@unocss/core': 66.5.1
       magic-string: 0.30.19
 
-  '@unocss/astro@66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@unocss/astro@66.0.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@unocss/core': 66.0.0
       '@unocss/reset': 66.0.0
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - vue
 
@@ -10457,7 +10448,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.0.0
 
-  '@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@unocss/vite@66.0.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.0.0
@@ -10467,11 +10458,11 @@ snapshots:
       magic-string: 0.30.19
       tinyglobby: 0.2.15
       unplugin-utils: 0.2.5
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - vue
 
-  '@vitejs/plugin-legacy@5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))':
+  '@vitejs/plugin-legacy@5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/preset-env': 7.28.3(@babel/core@7.28.4)
@@ -10482,28 +10473,28 @@ snapshots:
       regenerator-runtime: 0.14.1
       systemjs: 6.15.1
       terser: 5.44.0
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.1.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
   '@vitest/eslint-plugin@1.3.12(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.6)(jsdom@16.7.0)(terser@5.44.0))':
@@ -10531,7 +10522,7 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.20(@types/node@22.18.6)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10827,7 +10818,7 @@ snapshots:
       eslint-plugin-toml: 0.12.0(eslint@9.36.0(jiti@2.5.1))
       eslint-plugin-unicorn: 61.0.2(eslint@9.36.0(jiti@2.5.1))
       eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))
-      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1)))
+      eslint-plugin-vue: 10.5.0(@stylistic/eslint-plugin@5.4.0(eslint@9.36.0(jiti@2.5.1)))(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1)))
       eslint-plugin-yml: 1.18.0(eslint@9.36.0(jiti@2.5.1))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.36.0(jiti@2.5.1))
       globals: 16.4.0
@@ -11955,7 +11946,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
 
-  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1))):
+  eslint-plugin-vue@10.5.0(@stylistic/eslint-plugin@5.4.0(eslint@9.36.0(jiti@2.5.1)))(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.36.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.36.0(jiti@2.5.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.5.1))
       eslint: 9.36.0(jiti@2.5.1)
@@ -11966,6 +11957,7 @@ snapshots:
       vue-eslint-parser: 10.2.0(eslint@9.36.0(jiti@2.5.1))
       xml-name-validator: 4.0.0
     optionalDependencies:
+      '@stylistic/eslint-plugin': 5.4.0(eslint@9.36.0(jiti@2.5.1))
       '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.8.3)
 
   eslint-plugin-yml@1.18.0(eslint@9.36.0(jiti@2.5.1)):
@@ -12698,7 +12690,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -12794,7 +12786,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -12809,7 +12801,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -12819,7 +12811,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12838,7 +12830,7 @@ snapshots:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -12881,7 +12873,7 @@ snapshots:
   jest-mock@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
 
   jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     optionalDependencies:
@@ -12917,7 +12909,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -12968,7 +12960,7 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
@@ -13001,7 +12993,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -13020,7 +13012,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -13028,7 +13020,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.5.2
+      '@types/node': 22.18.6
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -13190,20 +13182,15 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  lint-staged@16.1.6:
+  lint-staged@16.2.0:
     dependencies:
-      chalk: 5.6.2
       commander: 14.0.1
-      debug: 4.4.3
-      lilconfig: 3.1.3
       listr2: 9.0.4
       micromatch: 4.0.8
       nano-spawn: 1.0.3
       pidtree: 0.6.0
       string-argv: 0.3.2
       yaml: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
 
   listr2@9.0.4:
     dependencies:
@@ -15113,8 +15100,6 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.12.0: {}
-
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -15207,16 +15192,16 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))):
+  unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))):
     dependencies:
       '@unocss-applet/preset-applet': 0.11.0
       '@unocss-applet/preset-rem-rpx': 0.11.0
       '@unocss-applet/transformer-attributify': 0.11.0
-      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
-  unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)):
+  unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)):
     dependencies:
-      '@unocss/astro': 66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/astro': 66.0.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@unocss/cli': 66.0.0
       '@unocss/core': 66.0.0
       '@unocss/postcss': 66.0.0(postcss@8.5.6)
@@ -15233,9 +15218,9 @@ snapshots:
       '@unocss/transformer-compile-class': 66.0.0
       '@unocss/transformer-directives': 66.0.0
       '@unocss/transformer-variant-group': 66.0.0
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -15339,7 +15324,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.20(@types/node@22.18.6)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15351,7 +15336,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-inspect@0.8.9(rollup@4.52.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)):
+  vite-plugin-inspect@0.8.9(rollup@4.52.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
@@ -15362,14 +15347,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.2
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
   vite-plugin-uni-polyfill@0.1.0: {}
 
-  vite@5.4.20(@types/node@22.18.6)(terser@5.44.0):
+  vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -15377,26 +15362,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.18.6
       fsevents: 2.3.3
-      terser: 5.44.0
-
-  vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.52.0
-    optionalDependencies:
-      '@types/node': 24.5.2
-      fsevents: 2.3.3
       sass: 1.78.0
       terser: 5.44.0
 
-  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)):
+  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)):
     dependencies:
       '@iconify-json/logos': 1.2.9
       '@iconify-json/vscode-icons': 1.2.30
       '@iconify/utils': 3.0.2
       markdown-it: 14.1.0
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15418,7 +15393,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.6.4(@algolia/client-search@5.37.0)(@types/node@24.5.2)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2):
+  vitepress@1.6.4(@algolia/client-search@5.37.0)(@types/node@22.18.6)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.37.0)(search-insights@2.17.3)
@@ -15427,7 +15402,7 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.21
       '@vueuse/core': 12.8.2(typescript@5.9.2)
@@ -15436,7 +15411,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
-      vite: 5.4.20(@types/node@24.5.2)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
     optionalDependencies:
       postcss: 8.5.6
@@ -15489,7 +15464,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.20(@types/node@22.18.6)(terser@5.44.0)
+      vite: 5.4.20(@types/node@22.18.6)(sass@1.78.0)(terser@5.44.0)
       vite-node: 3.2.4(@types/node@22.18.6)(terser@5.44.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,132 +9,10 @@ catalogs:
     '@uni-helper/vite-plugin-uni-components':
       specifier: ^0.2.0
       version: 0.2.0
-    '@uni-helper/vite-plugin-uni-manifest':
-      specifier: ^0.2.8
-      version: 0.2.8
-    '@uni-helper/vite-plugin-uni-pages':
-      specifier: ^0.3.14
-      version: 0.3.14
-    unbuild:
-      specifier: ~3.5.0
-      version: 3.5.0
-    unplugin-auto-import:
-      specifier: ^20.1.0
-      version: 20.1.0
-    vite:
-      specifier: ^5.4.20
-      version: 5.4.20
-    vite-plugin-inspect:
-      specifier: ~0.8.9
-      version: 0.8.9
-    vite-plugin-uni-polyfill:
-      specifier: ^0.1.0
-      version: 0.1.0
-    vitepress:
-      specifier: ^1.6.4
-      version: 1.6.4
-    vitepress-plugin-group-icons:
-      specifier: ^1.6.3
-      version: 1.6.3
-    vitepress-plugin-llms:
-      specifier: ^1.7.5
-      version: 1.7.5
-  cli:
-    bumpp:
-      specifier: ^10.2.3
-      version: 10.2.3
-    pncat:
-      specifier: ^0.5.4
-      version: 0.5.4
-  dcloudio:
-    '@dcloudio/types':
-      specifier: ^3.4.21
-      version: 3.4.21
-    '@dcloudio/uni-app':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-app-harmony':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-app-plus':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-automator':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-cli-shared':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-components':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-h5':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-alipay':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-baidu':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-jd':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-kuaishou':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-lark':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-qq':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-toutiao':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-weixin':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-mp-xhs':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-quickapp-webview':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/uni-stacktracey':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
-    '@dcloudio/vite-plugin-uni':
-      specifier: 3.0.0-4070620250821001
-      version: 3.0.0-4070620250821001
   dev:
-    '@antfu/ni':
-      specifier: ^25.0.0
-      version: 25.0.0
-    '@mini-types/alipay':
-      specifier: ^3.0.14
-      version: 3.0.14
-    '@uni-helper/plugin-uni':
-      specifier: ^0.1.0
-      version: 0.1.0
-    '@uni-helper/uni-app-types':
-      specifier: ^1.0.0-alpha.6
-      version: 1.0.0-alpha.6
-    '@xiaohe01/tsconfig':
-      specifier: ^2.0.0
-      version: 2.0.0
-    miniprogram-api-typings:
-      specifier: ^4.1.0
-      version: 4.1.0
     oxc-parser:
       specifier: ^0.89.0
       version: 0.89.0
-    oxc-walker:
-      specifier: ^0.5.2
-      version: 0.5.2
-    typescript:
-      specifier: ~5.8.3
-      version: 5.8.3
   frontend:
     '@vue/runtime-core':
       specifier: ~3.4.38
@@ -142,92 +20,6 @@ catalogs:
     echarts:
       specifier: ^5.6.0
       version: 5.6.0
-    pinia:
-      specifier: 2.2.4
-      version: 2.2.4
-    vue-tsc:
-      specifier: ~2.1.10
-      version: 2.1.10
-    wot-design-uni:
-      specifier: ^1.12.4
-      version: 1.12.4
-  icons:
-    '@iconify-json/carbon':
-      specifier: ^1.2.13
-      version: 1.2.13
-  lint:
-    '@xiaohe01/eslint-config':
-      specifier: ^2.3.0
-      version: 2.3.0
-    '@xiaohe01/stylelint-config':
-      specifier: ^2.4.0
-      version: 2.4.0
-    eslint:
-      specifier: ^9.35.0
-      version: 9.35.0
-    lint-staged:
-      specifier: ^16.1.6
-      version: 16.1.6
-    simple-git-hooks:
-      specifier: ^2.13.1
-      version: 2.13.1
-    stylelint:
-      specifier: ^16.24.0
-      version: 16.24.0
-  node:
-    chalk:
-      specifier: ^5.6.2
-      version: 5.6.2
-    consola:
-      specifier: ^3.4.2
-      version: 3.4.2
-    execa:
-      specifier: ^9.6.0
-      version: 9.6.0
-    fs-extra:
-      specifier: ^11.3.2
-      version: 11.3.2
-    rimraf:
-      specifier: ^6.0.1
-      version: 6.0.1
-  script:
-    esno:
-      specifier: ^4.8.0
-      version: 4.8.0
-  style:
-    '@uni-helper/unocss-preset-uni':
-      specifier: ^0.2.11
-      version: 0.2.11
-    sass:
-      specifier: ~1.78.0
-      version: 1.78.0
-    unocss:
-      specifier: ~66.0.0
-      version: 66.0.0
-    unocss-applet:
-      specifier: ^0.11.0
-      version: 0.11.0
-  test:
-    vitest:
-      specifier: ^3.2.4
-      version: 3.2.4
-  types:
-    '@types/fs-extra':
-      specifier: ^11.0.4
-      version: 11.0.4
-    '@types/lodash-es':
-      specifier: ^4.17.12
-      version: 4.17.12
-  utils:
-    '@antfu/utils':
-      specifier: ^9.2.0
-      version: 9.2.0
-    '@vueuse/core':
-      specifier: ^12.8.2
-      version: 12.8.2
-    lodash-es:
-      specifier: ^4.17.21
-      version: 4.17.21
 
 overrides:
   mkdist: 2.3.0
@@ -348,9 +140,6 @@ importers:
       oxc-parser:
         specifier: catalog:dev
         version: 0.89.0
-      oxc-walker:
-        specifier: catalog:dev
-        version: 0.5.2(oxc-parser@0.89.0)
       vue:
         specifier: 3.4.38
         version: 3.4.38(typescript@5.9.2)
@@ -5182,9 +4971,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  magic-regexp@0.10.0:
-    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
-
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
@@ -5615,11 +5401,6 @@ packages:
   oxc-parser@0.89.0:
     resolution: {integrity: sha512-BO/RxfooJxuoofjC1USPmZ9a32pzjwXFAM1MHO2zPSij9fkgngHMzAu4t8XY1zrXMmoLBv13fh6LUZ906Rjx+g==}
     engines: {node: '>=20.0.0'}
-
-  oxc-walker@0.5.2:
-    resolution: {integrity: sha512-XYoZqWwApSKUmSDEFeOKdy3Cdh95cOcSU8f7yskFWE4Rl3cfL5uwyY+EV7Brk9mdNLy+t5SseJajd6g7KncvlA==}
-    peerDependencies:
-      oxc-parser: '>=0.72.0'
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -6755,9 +6536,6 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
-
-  type-level-regexp@0.1.17:
-    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
@@ -13295,16 +13073,6 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  magic-regexp@0.10.0:
-    dependencies:
-      estree-walker: 3.0.3
-      magic-string: 0.30.19
-      mlly: 1.8.0
-      regexp-tree: 0.1.27
-      type-level-regexp: 0.1.17
-      ufo: 1.6.1
-      unplugin: 2.3.10
-
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -13913,11 +13681,6 @@ snapshots:
       '@oxc-parser/binding-wasm32-wasi': 0.89.0
       '@oxc-parser/binding-win32-arm64-msvc': 0.89.0
       '@oxc-parser/binding-win32-x64-msvc': 0.89.0
-
-  oxc-walker@0.5.2(oxc-parser@0.89.0):
-    dependencies:
-      magic-regexp: 0.10.0
-      oxc-parser: 0.89.0
 
   p-limit@2.3.0:
     dependencies:
@@ -15073,8 +14836,6 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-
-  type-level-regexp@0.1.17: {}
 
   typedarray-to-buffer@3.1.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,15 @@ settings:
 
 catalogs:
   build:
+    '@rollup/plugin-commonjs':
+      specifier: ^28.0.6
+      version: 28.0.6
+    '@rollup/plugin-node-resolve':
+      specifier: ^16.0.1
+      version: 16.0.1
+    '@rollup/plugin-terser':
+      specifier: ^0.4.4
+      version: 0.4.4
     '@uni-helper/vite-plugin-uni-components':
       specifier: ^0.2.1
       version: 0.2.1
@@ -123,6 +132,9 @@ catalogs:
     '@xiaohe01/tsconfig':
       specifier: ^2.0.0
       version: 2.0.0
+    minimist:
+      specifier: ^1.2.8
+      version: 1.2.8
     miniprogram-api-typings:
       specifier: ^4.1.0
       version: 4.1.0
@@ -172,6 +184,9 @@ catalogs:
       specifier: ^16.24.0
       version: 16.24.0
   node:
+    '@clack/prompts':
+      specifier: ^0.11.0
+      version: 0.11.0
     chalk:
       specifier: ^5.6.2
       version: 5.6.2
@@ -215,6 +230,9 @@ catalogs:
     '@types/lodash-es':
       specifier: ^4.17.12
       version: 4.17.12
+    '@types/minimist':
+      specifier: ^1.2.5
+      version: 1.2.5
   utils:
     '@antfu/utils':
       specifier: ^9.2.1
@@ -334,6 +352,31 @@ importers:
       vue:
         specifier: 3.4.38
         version: 3.4.38(typescript@5.9.2)
+
+  packages/c2e:
+    dependencies:
+      '@rollup/plugin-terser':
+        specifier: catalog:build
+        version: 0.4.4(rollup@4.52.0)
+    devDependencies:
+      '@clack/prompts':
+        specifier: catalog:node
+        version: 0.11.0
+      '@rollup/plugin-commonjs':
+        specifier: catalog:build
+        version: 28.0.6(rollup@4.52.0)
+      '@rollup/plugin-node-resolve':
+        specifier: catalog:build
+        version: 16.0.1(rollup@4.52.0)
+      '@types/minimist':
+        specifier: catalog:types
+        version: 1.2.5
+      chalk:
+        specifier: catalog:node
+        version: 5.6.2
+      minimist:
+        specifier: catalog:dev
+        version: 1.2.8
 
   packages/core:
     devDependencies:
@@ -2363,6 +2406,15 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/plugin-terser@0.4.4':
+    resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -2597,6 +2649,9 @@ packages:
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -6142,6 +6197,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -6351,6 +6409,9 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
@@ -6417,6 +6478,9 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  smob@1.5.0:
+    resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -9857,6 +9921,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.52.0
 
+  '@rollup/plugin-terser@0.4.4(rollup@4.52.0)':
+    dependencies:
+      serialize-javascript: 6.0.2
+      smob: 1.5.0
+      terser: 5.44.0
+    optionalDependencies:
+      rollup: 4.52.0
+
   '@rollup/pluginutils@5.3.0(rollup@4.52.0)':
     dependencies:
       '@types/estree': 1.0.8
@@ -10080,6 +10152,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdurl@2.0.0': {}
+
+  '@types/minimist@1.2.5': {}
 
   '@types/ms@2.1.0': {}
 
@@ -10422,7 +10496,7 @@ snapshots:
 
   '@unocss/rule-utils@66.0.0':
     dependencies:
-      '@unocss/core': 66.0.0
+      '@unocss/core': 66.5.1
       magic-string: 0.30.19
 
   '@unocss/rule-utils@66.5.1':
@@ -14367,6 +14441,10 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   range-parser@1.2.1: {}
 
   raw-body@2.5.2:
@@ -14613,6 +14691,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  serialize-javascript@6.0.2:
+    dependencies:
+      randombytes: 2.1.0
+
   serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
@@ -14697,6 +14779,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  smob@1.5.0: {}
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ catalogs:
       specifier: ^0.2.8
       version: 0.2.8
     '@uni-helper/vite-plugin-uni-pages':
-      specifier: ^0.3.11
-      version: 0.3.11
+      specifier: ^0.3.14
+      version: 0.3.14
     unbuild:
-      specifier: ~3.6.1
-      version: 3.6.1
+      specifier: ~3.5.0
+      version: 3.5.0
     unplugin-auto-import:
       specifier: ^20.1.0
       version: 20.1.0
@@ -126,6 +126,12 @@ catalogs:
     miniprogram-api-typings:
       specifier: ^4.1.0
       version: 4.1.0
+    oxc-parser:
+      specifier: ^0.89.0
+      version: 0.89.0
+    oxc-walker:
+      specifier: ^0.5.2
+      version: 0.5.2
     typescript:
       specifier: ~5.8.3
       version: 5.8.3
@@ -179,8 +185,8 @@ catalogs:
       specifier: ^9.6.0
       version: 9.6.0
     fs-extra:
-      specifier: ^11.3.1
-      version: 11.3.1
+      specifier: ^11.3.2
+      version: 11.3.2
     rimraf:
       specifier: ^6.0.1
       version: 6.0.1
@@ -224,6 +230,7 @@ catalogs:
       version: 4.17.21
 
 overrides:
+  mkdist: 2.3.0
   vue: 3.4.38
 
 importers:
@@ -250,7 +257,7 @@ importers:
         version: 1.0.0-alpha.6(typescript@5.8.3)(vue@3.4.38(typescript@5.8.3))
       '@xiaohe01/eslint-config':
         specifier: catalog:lint
-        version: 2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0))
+        version: 2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0))
       '@xiaohe01/stylelint-config':
         specifier: catalog:lint
         version: 2.4.0(postcss@8.5.6)(stylelint@16.24.0(typescript@5.8.3))
@@ -277,7 +284,7 @@ importers:
         version: 9.6.0
       fs-extra:
         specifier: catalog:node
-        version: 11.3.1
+        version: 11.3.2
       lint-staged:
         specifier: catalog:lint
         version: 16.1.6
@@ -301,13 +308,13 @@ importers:
         version: 5.8.3
       unbuild:
         specifier: catalog:build
-        version: 3.6.1(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
+        version: 3.5.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
       vite:
         specifier: catalog:build
-        version: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+        version: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
       vitest:
         specifier: catalog:test
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0)
       vue-tsc:
         specifier: catalog:frontend
         version: 2.1.10(typescript@5.8.3)
@@ -316,10 +323,10 @@ importers:
     devDependencies:
       vitepress:
         specifier: catalog:build
-        version: 1.6.4(@algolia/client-search@5.37.0)(@types/node@24.3.3)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2)
+        version: 1.6.4(@algolia/client-search@5.37.0)(@types/node@24.5.1)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2)
       vitepress-plugin-group-icons:
         specifier: catalog:build
-        version: 1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
+        version: 1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
       vitepress-plugin-llms:
         specifier: catalog:build
         version: 1.7.5
@@ -331,13 +338,19 @@ importers:
     devDependencies:
       '@uni-helper/vite-plugin-uni-components':
         specifier: catalog:build
-        version: 0.2.0(rollup@4.50.1)
+        version: 0.2.0(rollup@4.50.2)
       '@vue/runtime-core':
         specifier: catalog:frontend
         version: 3.4.38
       echarts:
         specifier: catalog:frontend
         version: 5.6.0
+      oxc-parser:
+        specifier: catalog:dev
+        version: 0.89.0
+      oxc-walker:
+        specifier: catalog:dev
+        version: 0.5.2(oxc-parser@0.89.0)
       vue:
         specifier: 3.4.38
         version: 3.4.38(typescript@5.9.2)
@@ -358,49 +371,49 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-harmony':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-plus':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-components':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-h5':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-alipay':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-baidu':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-jd':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-kuaishou':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-lark':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-qq':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-toutiao':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-weixin':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-xhs':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-quickapp-webview':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@vueuse/core':
         specifier: catalog:utils
         version: 12.8.2(typescript@5.9.2)
@@ -425,16 +438,16 @@ importers:
     devDependencies:
       '@dcloudio/uni-automator':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-cli-shared':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-stacktracey':
         specifier: catalog:dcloudio
         version: 3.0.0-4070620250821001
       '@dcloudio/vite-plugin-uni':
         specifier: catalog:dcloudio
-        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@iconify-json/carbon':
         specifier: catalog:icons
         version: 1.2.13
@@ -443,19 +456,19 @@ importers:
         version: 4.17.12
       '@uni-helper/plugin-uni':
         specifier: catalog:dev
-        version: 0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       '@uni-helper/unocss-preset-uni':
         specifier: catalog:style
-        version: 0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       '@uni-helper/vite-plugin-uni-components':
         specifier: catalog:build
-        version: 0.2.0(rollup@4.50.1)
+        version: 0.2.0(rollup@4.50.2)
       '@uni-helper/vite-plugin-uni-manifest':
         specifier: catalog:build
-        version: 0.2.8(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
+        version: 0.2.8(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
       '@uni-helper/vite-plugin-uni-pages':
         specifier: catalog:build
-        version: 0.3.11(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
+        version: 0.3.14(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
       '@vue/runtime-core':
         specifier: catalog:frontend
         version: 3.4.38
@@ -464,16 +477,16 @@ importers:
         version: 1.78.0
       unocss:
         specifier: catalog:style
-        version: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+        version: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       unocss-applet:
         specifier: catalog:style
-        version: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+        version: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
       unplugin-auto-import:
         specifier: catalog:build
         version: 20.1.0(@vueuse/core@12.8.2(typescript@5.9.2))
       vite-plugin-inspect:
         specifier: catalog:build
-        version: 0.8.9(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
+        version: 0.8.9(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
       vite-plugin-uni-polyfill:
         specifier: catalog:build
         version: 0.1.0
@@ -1165,6 +1178,15 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@cacheable/memoize@2.0.1':
+    resolution: {integrity: sha512-WBLH37SynkCa39S6IrTSMQF3Wdv4/51WxuU5TuCNEqZcLgLGHme8NUxRTcDIO8ZZFXlslWbh9BD3DllixgPg6Q==}
+
+  '@cacheable/memory@2.0.1':
+    resolution: {integrity: sha512-Ufc7iQnRKFC8gjZVGOTOsMwM/vZtmsw3LafvctVXPm835ElgK3DpMe1U5i9sd6OieSkyJhXbAT2Q2FosXBBbAQ==}
+
+  '@cacheable/utils@2.0.1':
+    resolution: {integrity: sha512-sxHjO6wKn4/0wHCFYbh6tljj+ciP9BKgyBi09NLsor3sN+nu/Rt3FwLw6bYp7bp8usHpmcwUozrB/u4RuSw/eg==}
+
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
@@ -1334,6 +1356,15 @@ packages:
 
   '@dual-bundle/import-meta-resolve@4.2.1':
     resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
+
+  '@emnapi/core@1.5.0':
+    resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
+
+  '@emnapi/runtime@1.5.0':
+    resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@es-joy/jsdoccomment@0.50.2':
     resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
@@ -1854,8 +1885,8 @@ packages:
   '@iconify-json/logos@1.2.9':
     resolution: {integrity: sha512-G6VCdFnwZcrT6Eveq3m43oJfLw/CX8plwFcE+2jgv3fiGB64pTmnU7Yd1MNZ/eA+/Re2iEDhuCfSNOWTHwwK8w==}
 
-  '@iconify-json/simple-icons@1.2.51':
-    resolution: {integrity: sha512-vFH0QEHFG3rt9hZOR3oE/ZfAKFA7cS11UXttD/IphClEbiSTsPbpeeJ4kRYGDBUDmAKhBzk6jxHNG8VipwA69Q==}
+  '@iconify-json/simple-icons@1.2.52':
+    resolution: {integrity: sha512-c41YOMzBhl3hp58WJLxT+Qq3UhBd8GZAMkbS8ddlCuIGLW0COGe2YSfOA2+poA8/bxLhUQODRNjAy3KhiAOtzA==}
 
   '@iconify-json/vscode-icons@1.2.30':
     resolution: {integrity: sha512-dlTOc8w4a8/QNumZzMve+APJa6xQVXPZwo8qBk/MaYfY42NPrQT83QXkbTWKDkuEu/xgHPXvKZZBL7Yy12vYQw==}
@@ -1866,8 +1897,8 @@ packages:
   '@iconify/utils@2.3.0':
     resolution: {integrity: sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==}
 
-  '@iconify/utils@3.0.1':
-    resolution: {integrity: sha512-A78CUEnFGX8I/WlILxJCuIJXloL0j/OJ9PSchPAfCargEIKmUBWvvEMmKWB5oONwiUqlNt+5eRufdkLxeHIWYw==}
+  '@iconify/utils@3.0.2':
+    resolution: {integrity: sha512-EfJS0rLfVuRuJRn4psJHtK2A9TqVnkxPpHY6lYHiB9+8eSuudsxbwMiavocG45ujOo6FJ+CIRlRnlOGinzkaGQ==}
 
   '@intlify/core-base@9.1.9':
     resolution: {integrity: sha512-x5T0p/Ja0S8hs5xs+ImKyYckVkL4CzcEXykVYYV6rcbXxJTe2o58IquSqX9bdncVKbRZP7GlBU1EcRaQEEJ+vw==}
@@ -2155,6 +2186,10 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@keyv/bigmap@1.0.0':
+    resolution: {integrity: sha512-N2UsRSXlWwbvYKdFVS7sKqj6oXGegELh+zr9VripWDc8grsq8KBNp8JHI+9AQuUEFiM1S7+tm6lLp/lmbBCqCw==}
+    engines: {node: '>= 20'}
+
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
@@ -2167,6 +2202,9 @@ packages:
   '@mini-types/my@3.0.14':
     resolution: {integrity: sha512-aEgmM+rbEvEzTvqltCFRAg/h6KKs14M1y+FrOkz+hn2EyNpOVPesUzTjbRhSiFFsE3WdfBh54lHNYBahAmHq7w==}
 
+  '@napi-rs/wasm-runtime@1.0.5':
+    resolution: {integrity: sha512-TBr9Cf9onSAS2LQ2+QHx6XcC6h9+RIzJgbqG3++9TUZSH204AwEy5jg3BTQ0VATsyoGj4ee49tN/y6rvaOOtcg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2178,6 +2216,104 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-parser/binding-android-arm64@0.89.0':
+    resolution: {integrity: sha512-Tz0FoCIU/MGteWnCLk8UjN6EgNCnFO/HPrf6/Slg2snFYBaEv4kQVSfe5uN6DWlhuX0/Hk891bJif7kvQkXskg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.89.0':
+    resolution: {integrity: sha512-kypXATIbctk9djDWXuC7XGbfOgiNJgYpIHIN7lyIhEqYvvrpmSiRaufn2zIjzDxmJFyok4A7wHJH7LsNwrOZhw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.89.0':
+    resolution: {integrity: sha512-0mBLPC7LH6FCTfpq8vjZ12ZevOPN8XvrxV6zIyUlW2Xv/s4AJ5myn1Vqy3g0kCJYVoyTNWOLHzkTp2uDx0VQOw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.89.0':
+    resolution: {integrity: sha512-UWQai6zd3+w+Z7iRHkw8ZD5dwrlAWkbsBmK7nfNHwOa9gew/J10iS7aatX0YQ8MzpUVa5wIofGmB4kOoG/IzFg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.89.0':
+    resolution: {integrity: sha512-vfi2bef+VMp0bcPomQugQcpEe4GpYKhT2HFCgUplEMneQNuPj5z/rF6u1Ix0y13MisO8cbNhxP0oB1tvqmPA6Q==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.89.0':
+    resolution: {integrity: sha512-EvLiLQSYkBTtp8c91bjBCxlf0rMIq3jfcYopEx5jz9lv/nhJGrxkzVvj0kAN3f2iufbkk0PygKkSvQx0Kpy9zQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.89.0':
+    resolution: {integrity: sha512-jeI7qoHvvUIqLCN4FAPmTLpcQrlL3cuteH0HuYBmeVdBcJyPLAWAht7EaDlPjYOFvp4e9Tp3IqrpdqCztCWdAw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.89.0':
+    resolution: {integrity: sha512-Pxe89cKhKNvHm6eii1zWr711sEyxFzJxINYAP5SM7PgajQb9dZq8Le0e68NYADlsoXVc/zcYlo+aC2yhjxNMVA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.89.0':
+    resolution: {integrity: sha512-g9R9Uph7gi9SBYKop5SdNK3c9WCBZSeYkE3IU3dF5DZnR/xqBkVRKnc+LAuboijEhhqLw4XwbQ49Wd6cBDjSTg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.89.0':
+    resolution: {integrity: sha512-RFalRHelX4EFJcp3Byy4z5ZnYoEFSlRmgZECYfr/7yPSmo79DKL2VEHeVzIAKFbfTOPDIm0yw9BbUEBDritWDQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.89.0':
+    resolution: {integrity: sha512-BjU07UxFMSm0/7c79KBBCC2Meef45CQ7dg068xLK6voZgEY24NNq2F0xfl7FxBrymR/viluSP5gopQYjHXqc4A==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.89.0':
+    resolution: {integrity: sha512-RLecF47V/uy3voAt2BFywfh1RUtHlgdz/oG9oMG0E+A/3ZQPTEB1WuJyAnDsC0anxQS5W2J+/az3l5sL4/n54w==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-wasm32-wasi@0.89.0':
+    resolution: {integrity: sha512-h9uyojS96as3+KnvQ6MojTBHeHTpN88ejzoNxEcUbhgupIYTCp59G+5BQh7E+w4lrCuGmnjphFkca07RvWQpbQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.89.0':
+    resolution: {integrity: sha512-OGa7mETyx7Mg0ecLQraawzRrVQDinNP7WQQ7CjDD/Y1YgKM/8oN9xa5TaVe5dh66pbKOz49NJ4LccaUs58UaMQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.89.0':
+    resolution: {integrity: sha512-uNRWb1VNW/OiJf26rc6XY63kRoHmIXMpsKFjECTGIfaxwNDKx/mtJSvLQaFDZxoWuY9VsNrtOqNidgkYeW3tfQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.89.0':
+    resolution: {integrity: sha512-yuo+ECPIW5Q9mSeNmCDC2im33bfKuwW18mwkaHMQh8KakHYDzj4ci/q7wxf2qS3dMlVVCIyrs3kFtH5LmnlYnw==}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -2243,119 +2379,119 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.50.1':
-    resolution: {integrity: sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag==}
+  '@rollup/rollup-android-arm-eabi@4.50.2':
+    resolution: {integrity: sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.50.1':
-    resolution: {integrity: sha512-PZlsJVcjHfcH53mOImyt3bc97Ep3FJDXRpk9sMdGX0qgLmY0EIWxCag6EigerGhLVuL8lDVYNnSo8qnTElO4xw==}
+  '@rollup/rollup-android-arm64@4.50.2':
+    resolution: {integrity: sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.50.1':
-    resolution: {integrity: sha512-xc6i2AuWh++oGi4ylOFPmzJOEeAa2lJeGUGb4MudOtgfyyjr4UPNK+eEWTPLvmPJIY/pgw6ssFIox23SyrkkJw==}
+  '@rollup/rollup-darwin-arm64@4.50.2':
+    resolution: {integrity: sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.50.1':
-    resolution: {integrity: sha512-2ofU89lEpDYhdLAbRdeyz/kX3Y2lpYc6ShRnDjY35bZhd2ipuDMDi6ZTQ9NIag94K28nFMofdnKeHR7BT0CATw==}
+  '@rollup/rollup-darwin-x64@4.50.2':
+    resolution: {integrity: sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.50.1':
-    resolution: {integrity: sha512-wOsE6H2u6PxsHY/BeFHA4VGQN3KUJFZp7QJBmDYI983fgxq5Th8FDkVuERb2l9vDMs1D5XhOrhBrnqcEY6l8ZA==}
+  '@rollup/rollup-freebsd-arm64@4.50.2':
+    resolution: {integrity: sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.50.1':
-    resolution: {integrity: sha512-A/xeqaHTlKbQggxCqispFAcNjycpUEHP52mwMQZUNqDUJFFYtPHCXS1VAG29uMlDzIVr+i00tSFWFLivMcoIBQ==}
+  '@rollup/rollup-freebsd-x64@4.50.2':
+    resolution: {integrity: sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.50.1':
-    resolution: {integrity: sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.50.2':
+    resolution: {integrity: sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.50.1':
-    resolution: {integrity: sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.50.2':
+    resolution: {integrity: sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.50.1':
-    resolution: {integrity: sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw==}
+  '@rollup/rollup-linux-arm64-gnu@4.50.2':
+    resolution: {integrity: sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.50.1':
-    resolution: {integrity: sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w==}
+  '@rollup/rollup-linux-arm64-musl@4.50.2':
+    resolution: {integrity: sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.50.1':
-    resolution: {integrity: sha512-RPhTwWMzpYYrHrJAS7CmpdtHNKtt2Ueo+BlLBjfZEhYBhK00OsEqM08/7f+eohiF6poe0YRDDd8nAvwtE/Y62Q==}
+  '@rollup/rollup-linux-loong64-gnu@4.50.2':
+    resolution: {integrity: sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.50.1':
-    resolution: {integrity: sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q==}
+  '@rollup/rollup-linux-ppc64-gnu@4.50.2':
+    resolution: {integrity: sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.50.1':
-    resolution: {integrity: sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ==}
+  '@rollup/rollup-linux-riscv64-gnu@4.50.2':
+    resolution: {integrity: sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.50.1':
-    resolution: {integrity: sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg==}
+  '@rollup/rollup-linux-riscv64-musl@4.50.2':
+    resolution: {integrity: sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.50.1':
-    resolution: {integrity: sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg==}
+  '@rollup/rollup-linux-s390x-gnu@4.50.2':
+    resolution: {integrity: sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.50.1':
-    resolution: {integrity: sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA==}
+  '@rollup/rollup-linux-x64-gnu@4.50.2':
+    resolution: {integrity: sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.50.1':
-    resolution: {integrity: sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg==}
+  '@rollup/rollup-linux-x64-musl@4.50.2':
+    resolution: {integrity: sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openharmony-arm64@4.50.1':
-    resolution: {integrity: sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA==}
+  '@rollup/rollup-openharmony-arm64@4.50.2':
+    resolution: {integrity: sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.50.1':
-    resolution: {integrity: sha512-hpZB/TImk2FlAFAIsoElM3tLzq57uxnGYwplg6WDyAxbYczSi8O2eQ+H2Lx74504rwKtZ3N2g4bCUkiamzS6TQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.50.2':
+    resolution: {integrity: sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.50.1':
-    resolution: {integrity: sha512-SXjv8JlbzKM0fTJidX4eVsH+Wmnp0/WcD8gJxIZyR6Gay5Qcsmdbi9zVtnbkGPG8v2vMR1AD06lGWy5FLMcG7A==}
+  '@rollup/rollup-win32-ia32-msvc@4.50.2':
+    resolution: {integrity: sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.50.1':
-    resolution: {integrity: sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA==}
+  '@rollup/rollup-win32-x64-msvc@4.50.2':
+    resolution: {integrity: sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==}
     cpu: [x64]
     os: [win32]
 
@@ -2405,6 +2541,9 @@ packages:
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2475,8 +2614,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.3.3':
-    resolution: {integrity: sha512-GKBNHjoNw3Kra1Qg5UXttsY5kiWMEfoHq2TmXb+b1rcm6N7B3wTrFYIf/oSZ1xNQ+hVVijgLkiDZh7jRRsh+Gw==}
+  '@types/node@24.5.1':
+    resolution: {integrity: sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==}
 
   '@types/prettier@2.7.3':
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
@@ -2499,63 +2638,63 @@ packages:
   '@types/yargs@16.0.9':
     resolution: {integrity: sha512-tHhzvkFXZQeTECenFoRljLBYPZJ7jAVxqqtEI0qTLOmuultnFp4I9yKE17vTuhf7BkhCu7I4XuemPgikDVuYqA==}
 
-  '@typescript-eslint/eslint-plugin@8.43.0':
-    resolution: {integrity: sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==}
+  '@typescript-eslint/eslint-plugin@8.44.0':
+    resolution: {integrity: sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.43.0
+      '@typescript-eslint/parser': ^8.44.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.43.0':
-    resolution: {integrity: sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.43.0':
-    resolution: {integrity: sha512-htB/+D/BIGoNTQYffZw4uM4NzzuolCoaA/BusuSIcC8YjmBYQioew5VUZAYdAETPjeed0hqCaW7EHg+Robq8uw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.43.0':
-    resolution: {integrity: sha512-daSWlQ87ZhsjrbMLvpuuMAt3y4ba57AuvadcR7f3nl8eS3BjRc8L9VLxFLk92RL5xdXOg6IQ+qKjjqNEimGuAg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.43.0':
-    resolution: {integrity: sha512-ALC2prjZcj2YqqL5X/bwWQmHA2em6/94GcbB/KKu5SX3EBDOsqztmmX1kMkvAJHzxk7TazKzJfFiEIagNV3qEA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.43.0':
-    resolution: {integrity: sha512-qaH1uLBpBuBBuRf8c1mLJ6swOfzCXryhKND04Igr4pckzSEW9JX5Aw9AgW00kwfjWJF0kk0ps9ExKTfvXfw4Qg==}
+  '@typescript-eslint/parser@8.44.0':
+    resolution: {integrity: sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.43.0':
-    resolution: {integrity: sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.43.0':
-    resolution: {integrity: sha512-7Vv6zlAhPb+cvEpP06WXXy/ZByph9iL6BQRBDj4kmBsW98AqEeQHlj/13X+sZOrKSo9/rNKH4Ul4f6EICREFdw==}
+  '@typescript-eslint/project-service@8.44.0':
+    resolution: {integrity: sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.43.0':
-    resolution: {integrity: sha512-S1/tEmkUeeswxd0GGcnwuVQPFWo8NzZTOMxCvw8BX7OMxnNae+i8Tm7REQen/SwUIPoPqfKn7EaZ+YLpiB3k9g==}
+  '@typescript-eslint/scope-manager@8.44.0':
+    resolution: {integrity: sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.44.0':
+    resolution: {integrity: sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.44.0':
+    resolution: {integrity: sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.43.0':
-    resolution: {integrity: sha512-T+S1KqRD4sg/bHfLwrpF/K3gQLBM1n7Rp7OjjikjTEssI2YJzQpi5WXoynOaQ93ERIuq3O8RBTOUYDKszUCEHw==}
+  '@typescript-eslint/types@8.44.0':
+    resolution: {integrity: sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.44.0':
+    resolution: {integrity: sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.44.0':
+    resolution: {integrity: sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.44.0':
+    resolution: {integrity: sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -2599,8 +2738,8 @@ packages:
     peerDependencies:
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  '@uni-helper/vite-plugin-uni-pages@0.3.11':
-    resolution: {integrity: sha512-LnMkZsNdItz950TX2PYomkvtYDW8lFOGfKmmAKpw2LUUD28VCnxP8E8+rzB5nLM0vyEQeMCzHe3z378R/h/snw==}
+  '@uni-helper/vite-plugin-uni-pages@0.3.14':
+    resolution: {integrity: sha512-CR/Are/3K4KebMkNaIjS0VzrNwhEX79Ve/SBuVZSqrXVNvo8dSOP4JHbgmOPaMgPypZlO6mN7HibOP/0crySXw==}
     peerDependencies:
       vite: ^5.0.0
 
@@ -2746,8 +2885,8 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: 3.4.38
 
-  '@vitest/eslint-plugin@1.3.9':
-    resolution: {integrity: sha512-wsNe7xy44ovm/h9ISDkDNcv0aOnUsaOYDqan2y6qCFAUQ0odFr6df/+FdGKHZN+mCM+SvIDWoXuvm5T5V3Kh6w==}
+  '@vitest/eslint-plugin@1.3.12':
+    resolution: {integrity: sha512-cSEyUYGj8j8SLqKrzN7BlfsJ3wG67eRT25819PXuyoSBogLXiyagdKx4MHWHV1zv+EEuyMXsEKkBEKzXpxyBrg==}
     peerDependencies:
       eslint: '>= 8.57.0'
       typescript: '>= 5.0.0'
@@ -3210,8 +3349,8 @@ packages:
     resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
     engines: {node: '>=6.0.0'}
 
-  baseline-browser-mapping@2.8.3:
-    resolution: {integrity: sha512-mcE+Wr2CAhHNWxXN/DdTI+n4gsPc5QpXpWnyCQWiQYIYZX+ZMJ8juXZgjRa/0/YPJo/NSsgW15/YgmI4nbysYw==}
+  baseline-browser-mapping@2.8.4:
+    resolution: {integrity: sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==}
     hasBin: true
 
   binary-extensions@2.3.0:
@@ -3251,8 +3390,8 @@ packages:
     peerDependencies:
       browserslist: '*'
 
-  browserslist@4.26.0:
-    resolution: {integrity: sha512-P9go2WrP9FiPwLv3zqRD/Uoxo0RSHjzFCiQz7d4vbmwNqQFo9T9WCeP/Qn5EbcKQY6DBbkxEXNcpJOmncNrb7A==}
+  browserslist@4.26.2:
+    resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3294,8 +3433,8 @@ packages:
       magicast:
         optional: true
 
-  c12@3.2.0:
-    resolution: {integrity: sha512-ixkEtbYafL56E6HiFuonMm1ZjoKtIo7TH68/uiEq4DAwv9NcUX2nJ95F8TrbMeNjqIkZpruo3ojXQJ+MGG5gcQ==}
+  c12@3.3.0:
+    resolution: {integrity: sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==}
     peerDependencies:
       magicast: ^0.3.5
     peerDependenciesMeta:
@@ -3310,8 +3449,8 @@ packages:
     resolution: {integrity: sha512-XN5qEpfNQCJ8jRaZgitSkkukjMRCGio+X3Ks5KUbGGlPbV+pSem1l9VuzooCBXOiMFshUZgyYqg6rgN8rjkb/w==}
     engines: {node: '>=8'}
 
-  cacheable@1.10.4:
-    resolution: {integrity: sha512-Gd7ccIUkZ9TE2odLQVS+PDjIvQCdJKUlLdJRVvZu0aipj07Qfx+XIej7hhDrKGGoIxV5m5fT/kOJNJPQhQneRg==}
+  cacheable@2.0.1:
+    resolution: {integrity: sha512-MSKxcybpxB5kcWKpj+1tPBm2os4qKKGxDovsZmLhZmWIDYp8EgtC45C5zk1fLe1IC9PpI4ZE4eyryQH0N10PKA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -3336,8 +3475,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001741:
-    resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
+  caniuse-lite@1.0.30001743:
+    resolution: {integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3411,9 +3550,9 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
-  cli-truncate@4.0.0:
-    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
-    engines: {node: '>=18'}
+  cli-truncate@5.1.0:
+    resolution: {integrity: sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g==}
+    engines: {node: '>=20'}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -3772,8 +3911,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.218:
-    resolution: {integrity: sha512-uwwdN0TUHs8u6iRgN8vKeWZMRll4gBkz+QMqdS7DDe49uiK68/UX92lFb61oiFPrpYZNeZIqa4bA7O6Aiasnzg==}
+  electron-to-chromium@1.5.219:
+    resolution: {integrity: sha512-JqaXfxHOS0WvKweEnrPHWRm8cnPVbdB7vXCQHPPFoAJFM3xig5/+/H08ZVkvJf4unvj8yncKy6MerOPj1NW1GQ==}
 
   emittery@0.8.1:
     resolution: {integrity: sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==}
@@ -3819,8 +3958,8 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
-  error-ex@1.3.2:
-    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   error-stack-parser-es@0.1.5:
     resolution: {integrity: sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==}
@@ -3961,8 +4100,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  eslint-plugin-n@17.22.0:
-    resolution: {integrity: sha512-+YQ4dW8gg3eVZ3A8lL6zugEmA+Le5IEpCXsI8vKvDvSIB8gEh2N3PKqDwI+J8uLb7nphTJkwiv2e5OlnEDNvpQ==}
+  eslint-plugin-n@17.23.0:
+    resolution: {integrity: sha512-aPePGxUr5LezcXmMRBF83eK1MmqUYY1NdLdHC+jdpfc5b98eL7yDXY20gXJ6DcTxrHBhrLsfYYqo7J+m0h9YXQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.23.0'
@@ -4224,8 +4363,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flat-cache@6.1.13:
-    resolution: {integrity: sha512-gmtS2PaUjSPa4zjObEIn4WWliKyZzYljgxODBfxugpK6q6HU9ClXzgCJ+nlcPKY9Bt090ypTOLIFWkV0jbKFjw==}
+  flat-cache@6.1.14:
+    resolution: {integrity: sha512-ExZSCSV9e7v/Zt7RzCbX57lY2dnPdxzU/h3UE6WJ6NtEMfwBd8jmi1n4otDEUfz+T/R+zxrFDpICFdjhD3H/zw==}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
@@ -4269,8 +4408,8 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
 
-  fs-extra@11.3.1:
-    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
+  fs-extra@11.3.2:
+    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
 
   fs-minipass@2.1.0:
@@ -4577,10 +4716,6 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-
-  is-fullwidth-code-point@4.0.0:
-    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
-    engines: {node: '>=12'}
 
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -4968,8 +5103,8 @@ packages:
     engines: {node: '>=20.17'}
     hasBin: true
 
-  listr2@9.0.3:
-    resolution: {integrity: sha512-0aeh5HHHgmq1KRdMMDHfhMWQmIT/m7nRDTlxlFqni2Sp0had9baqsjJRvDGdlvgd6NmPE0nPloOipiQJGFtTHQ==}
+  listr2@9.0.4:
+    resolution: {integrity: sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ==}
     engines: {node: '>=20.0.0'}
 
   load-bmfont@1.4.2:
@@ -5046,6 +5181,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-regexp@0.10.0:
+    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
@@ -5311,8 +5449,8 @@ packages:
   miniprogram-api-typings@4.1.0:
     resolution: {integrity: sha512-4RBsz27nBKyRkVGoNkRaPx24/KeJBw3zaaIlXDR8s/WBh2PbcUAc+q7wLLbp7Qsmb3bLzzUu7tqAti+B06kmjg==}
 
-  minisearch@7.1.2:
-    resolution: {integrity: sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==}
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -5330,15 +5468,15 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  mkdist@2.4.1:
-    resolution: {integrity: sha512-Ezk0gi04GJBkqMfsksICU5Rjoemc4biIekwgrONWVPor2EO/N9nBgN6MZXAf7Yw4mDDhrNyKbdETaHNevfumKg==}
+  mkdist@2.3.0:
+    resolution: {integrity: sha512-thkRk+pHdudjdZT3FJpPZ2+pncI6mGlH/B+KBVddlZj4MrFGW41sRIv1wZawZUHU8v7cttGaj+5nx8P+dG664A==}
     hasBin: true
     peerDependencies:
-      sass: ^1.92.1
-      typescript: '>=5.9.2'
+      sass: ^1.85.0
+      typescript: '>=5.7.3'
       vue: 3.4.38
       vue-sfc-transformer: ^0.1.1
-      vue-tsc: ^1.8.27 || ^2.0.21 || ^3.0.0
+      vue-tsc: ^1.8.27 || ^2.0.21
     peerDependenciesMeta:
       sass:
         optional: true
@@ -5426,8 +5564,8 @@ packages:
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
-  nypm@0.6.1:
-    resolution: {integrity: sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==}
+  nypm@0.6.2:
+    resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
@@ -5473,6 +5611,15 @@ packages:
   os-locale-s-fix@1.0.8-fix-1:
     resolution: {integrity: sha512-Sv0OvhPiMutICiwORAUefv02DCPb62IelBmo8ZsSrRHyI3FStqIWZvjqDkvtjU+lcujo7UNir+dCwKSqlEQ/5w==}
     engines: {node: '>=10', yarn: ^1.22.4}
+
+  oxc-parser@0.89.0:
+    resolution: {integrity: sha512-BO/RxfooJxuoofjC1USPmZ9a32pzjwXFAM1MHO2zPSij9fkgngHMzAu4t8XY1zrXMmoLBv13fh6LUZ906Rjx+g==}
+    engines: {node: '>=20.0.0'}
+
+  oxc-walker@0.5.2:
+    resolution: {integrity: sha512-XYoZqWwApSKUmSDEFeOKdy3Cdh95cOcSU8f7yskFWE4Rl3cfL5uwyY+EV7Brk9mdNLy+t5SseJajd6g7KncvlA==}
+    peerDependencies:
+      oxc-parser: '>=0.72.0'
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -5604,6 +5751,9 @@ packages:
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  perfect-debounce@2.0.0:
+    resolution: {integrity: sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==}
 
   phin@2.9.3:
     resolution: {integrity: sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==}
@@ -5948,6 +6098,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-bytes@6.1.1:
+    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
   pretty-bytes@7.0.1:
     resolution: {integrity: sha512-285/jRCYIbMGDciDdrw0KPNC4LKEEwz/bwErcYNxSJOi4CpGUuLpb9gQpg3XJP0XYj9ldSRluXxih4lX2YN8Xw==}
     engines: {node: '>=20'}
@@ -5956,8 +6110,8 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  pretty-ms@9.2.0:
-    resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
   process@0.11.10:
@@ -6155,8 +6309,8 @@ packages:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0
 
-  rollup@4.50.1:
-    resolution: {integrity: sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==}
+  rollup@4.50.2:
+    resolution: {integrity: sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -6278,10 +6432,6 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  slice-ansi@5.0.0:
-    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
-    engines: {node: '>=12'}
-
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
@@ -6356,6 +6506,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.1.0:
+    resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
+    engines: {node: '>=20'}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -6578,6 +6732,9 @@ packages:
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsx@4.20.5:
     resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
     engines: {node: '>=18.0.0'}
@@ -6599,6 +6756,9 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-level-regexp@0.1.17:
+    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
+
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
@@ -6618,11 +6778,11 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
-  unbuild@3.6.1:
-    resolution: {integrity: sha512-+U5CdtrdjfWkZhuO4N9l5UhyiccoeMEXIc2Lbs30Haxb+tRwB3VwB8AoZRxlAzORXunenSo+j6lh45jx+xkKgg==}
+  unbuild@3.5.0:
+    resolution: {integrity: sha512-DPFttsiADnHRb/K+yJ9r9jdn6JyXlsmdT0S12VFC14DFSJD+cxBnHq+v0INmqqPVPxOoUjvJFYUVIb02rWnVeA==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.9.2
+      typescript: ^5.7.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6633,8 +6793,8 @@ packages:
   unconfig@7.3.3:
     resolution: {integrity: sha512-QCkQoOnJF8L107gxfHL0uavn7WD9b3dpBcFX6HtfQYmjw2YzWxGuFQ0N0J6tE9oguCBJn9KOvfqYDCMPHIZrBA==}
 
-  undici-types@7.10.0:
-    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+  undici-types@7.12.0:
+    resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -6648,8 +6808,8 @@ packages:
     resolution: {integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==}
     engines: {node: '>=4'}
 
-  unicode-property-aliases-ecmascript@2.1.0:
-    resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
+  unicode-property-aliases-ecmascript@2.2.0:
+    resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
   unicorn-magic@0.1.0:
@@ -7318,7 +7478,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.28.4
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -8021,6 +8181,20 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@cacheable/memoize@2.0.1':
+    dependencies:
+      '@cacheable/utils': 2.0.1
+
+  '@cacheable/memory@2.0.1':
+    dependencies:
+      '@cacheable/memoize': 2.0.1
+      '@cacheable/utils': 2.0.1
+      '@keyv/bigmap': 1.0.0
+      hookified: 1.12.0
+      keyv: 5.5.1
+
+  '@cacheable/utils@2.0.1': {}
+
   '@clack/core@0.5.0':
     dependencies:
       picocolors: 1.1.1
@@ -8049,10 +8223,10 @@ snapshots:
 
   '@dcloudio/types@3.4.21': {}
 
-  '@dcloudio/uni-app-harmony@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-harmony@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       debug: 4.4.3
       fs-extra: 10.1.0
       licia: 1.48.0
@@ -8067,10 +8241,10 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-plus@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-plus@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-uts': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-app-vue': 3.0.0-4070620250821001
       debug: 4.4.3
       fs-extra: 10.1.0
@@ -8086,18 +8260,18 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-uts@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-uts@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-nvue-styler': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -8121,14 +8295,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-app-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-nvue-styler': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       debug: 4.4.3
@@ -8146,16 +8320,16 @@ snapshots:
 
   '@dcloudio/uni-app-vue@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-app@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-app@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@dcloudio/types': 3.4.21
-      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-components': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-components': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-console': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
-      '@dcloudio/uni-push': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-push': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@dcloudio/uni-stat': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-stat': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@vue/shared': 3.4.21
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8166,9 +8340,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-automator@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-automator@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(jest-environment-node@27.5.1)(jest@27.0.4)(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       address: 1.2.2
       cross-env: 7.0.3
       debug: 4.4.3
@@ -8193,7 +8367,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-cli-shared@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-cli-shared@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
@@ -8205,7 +8379,7 @@ snapshots:
       '@intlify/core-base': 9.1.9
       '@intlify/shared': 9.1.9
       '@intlify/vue-devtools': 9.1.9
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -8253,9 +8427,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cloud@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-cloud@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8269,10 +8443,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-components@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-components@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-h5': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cloud': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-h5': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8283,9 +8457,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-console@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-console@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -8296,11 +8470,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-h5-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-h5-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/server-renderer': 3.4.21(vue@3.4.38(typescript@5.9.2))
@@ -8325,9 +8499,9 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@dcloudio/uni-h5@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-h5@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-h5-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-h5-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-h5-vue': 3.0.0-4070620250821001(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
@@ -8350,10 +8524,10 @@ snapshots:
 
   '@dcloudio/uni-i18n@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-mp-alipay@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-alipay@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8367,14 +8541,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-baidu@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-baidu@3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-app': 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-app': 3.0.0-4070620250821001(@dcloudio/types@3.4.21)(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -8396,12 +8570,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-compiler@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-compiler@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
@@ -8416,11 +8590,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-jd@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-jd@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8433,13 +8607,13 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-kuaishou@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-kuaishou@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-weixin': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -8455,12 +8629,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-lark@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-lark@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-toutiao': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-toutiao': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8474,10 +8648,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-qq@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-qq@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8491,11 +8665,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-toutiao@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-toutiao@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-core': 3.4.21
@@ -8509,11 +8683,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-vite@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-i18n': 3.0.0-4070620250821001
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/compiler-dom': 3.4.21
@@ -8534,10 +8708,10 @@ snapshots:
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
 
-  '@dcloudio/uni-mp-weixin@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-weixin@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8558,11 +8732,11 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-xhs@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-mp-xhs@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-compiler': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8580,9 +8754,9 @@ snapshots:
       parse-css-font: 4.0.0
       postcss: 8.5.6
 
-  '@dcloudio/uni-push@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-push@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -8592,10 +8766,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-quickapp-webview@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-quickapp-webview@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
-      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-mp-vite': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-mp-vue': 3.0.0-4070620250821001
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       '@vue/shared': 3.4.21
@@ -8614,9 +8788,9 @@ snapshots:
 
   '@dcloudio/uni-stacktracey@3.0.0-4070620250821001': {}
 
-  '@dcloudio/uni-stat@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/uni-stat@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
       debug: 4.4.3
     transitivePeerDependencies:
@@ -8628,17 +8802,17 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
-      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/uni-cli-shared': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vue@3.4.38(typescript@5.9.2))
       '@dcloudio/uni-shared': 3.0.0-4070620250821001
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
-      '@vitejs/plugin-legacy': 5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))
-      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
+      '@vitejs/plugin-legacy': 5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))
+      '@vitejs/plugin-vue': 5.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -8655,7 +8829,7 @@ snapshots:
       picocolors: 1.1.1
       terser: 5.44.0
       unplugin-auto-import: 19.1.0(@vueuse/core@12.8.2(typescript@5.9.2))
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -8691,10 +8865,26 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
+  '@emnapi/core@1.5.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.5.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@es-joy/jsdoccomment@0.50.2':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/types': 8.44.0
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
@@ -8702,7 +8892,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.56.0':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/types': 8.44.0
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 5.1.1
@@ -9010,7 +9200,7 @@ snapshots:
     dependencies:
       '@iconify/types': 2.0.0
 
-  '@iconify-json/simple-icons@1.2.51':
+  '@iconify-json/simple-icons@1.2.52':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -9033,7 +9223,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@iconify/utils@3.0.1':
+  '@iconify/utils@3.0.2':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 9.2.0
@@ -9109,7 +9299,7 @@ snapshots:
   '@jest/console@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -9122,7 +9312,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -9156,14 +9346,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       jest-mock: 27.5.1
 
   '@jest/fake-timers@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -9181,7 +9371,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -9250,7 +9440,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -9557,6 +9747,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/bigmap@1.0.0':
+    dependencies:
+      hookified: 1.12.0
+
   '@keyv/serialize@1.1.1': {}
 
   '@mini-types/alipay@3.0.14':
@@ -9567,6 +9761,13 @@ snapshots:
   '@mini-types/global@3.0.14': {}
 
   '@mini-types/my@3.0.14': {}
+
+  '@napi-rs/wasm-runtime@1.0.5':
+    dependencies:
+      '@emnapi/core': 1.5.0
+      '@emnapi/runtime': 1.5.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9580,6 +9781,55 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@oxc-parser/binding-android-arm64@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.89.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.5
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.89.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.89.0':
+    optional: true
+
+  '@oxc-project/types@0.89.0': {}
+
   '@pkgr/core@0.2.9': {}
 
   '@polka/url@1.0.0-next.29': {}
@@ -9588,13 +9838,13 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rollup/plugin-alias@5.1.1(rollup@4.50.1)':
+  '@rollup/plugin-alias@5.1.1(rollup@4.50.2)':
     optionalDependencies:
-      rollup: 4.50.1
+      rollup: 4.50.2
 
-  '@rollup/plugin-commonjs@28.0.6(rollup@4.50.1)':
+  '@rollup/plugin-commonjs@28.0.6(rollup@4.50.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9602,100 +9852,100 @@ snapshots:
       magic-string: 0.30.19
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.50.1
+      rollup: 4.50.2
 
-  '@rollup/plugin-json@6.1.0(rollup@4.50.1)':
+  '@rollup/plugin-json@6.1.0(rollup@4.50.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
     optionalDependencies:
-      rollup: 4.50.1
+      rollup: 4.50.2
 
-  '@rollup/plugin-node-resolve@16.0.1(rollup@4.50.1)':
+  '@rollup/plugin-node-resolve@16.0.1(rollup@4.50.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.50.1
+      rollup: 4.50.2
 
-  '@rollup/plugin-replace@6.0.2(rollup@4.50.1)':
+  '@rollup/plugin-replace@6.0.2(rollup@4.50.2)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       magic-string: 0.30.19
     optionalDependencies:
-      rollup: 4.50.1
+      rollup: 4.50.2
 
-  '@rollup/pluginutils@5.3.0(rollup@4.50.1)':
+  '@rollup/pluginutils@5.3.0(rollup@4.50.2)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
-      rollup: 4.50.1
+      rollup: 4.50.2
 
-  '@rollup/rollup-android-arm-eabi@4.50.1':
+  '@rollup/rollup-android-arm-eabi@4.50.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.50.1':
+  '@rollup/rollup-android-arm64@4.50.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.50.1':
+  '@rollup/rollup-darwin-arm64@4.50.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.50.1':
+  '@rollup/rollup-darwin-x64@4.50.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.50.1':
+  '@rollup/rollup-freebsd-arm64@4.50.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.50.1':
+  '@rollup/rollup-freebsd-x64@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.50.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.50.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.50.1':
+  '@rollup/rollup-linux-arm64-gnu@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.50.1':
+  '@rollup/rollup-linux-arm64-musl@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.50.1':
+  '@rollup/rollup-linux-loong64-gnu@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.50.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.50.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.50.1':
+  '@rollup/rollup-linux-riscv64-musl@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.50.1':
+  '@rollup/rollup-linux-s390x-gnu@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.50.1':
+  '@rollup/rollup-linux-x64-gnu@4.50.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.50.1':
+  '@rollup/rollup-linux-x64-musl@4.50.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.50.1':
+  '@rollup/rollup-openharmony-arm64@4.50.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.50.1':
+  '@rollup/rollup-win32-arm64-msvc@4.50.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.50.1':
+  '@rollup/rollup-win32-ia32-msvc@4.50.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.50.1':
+  '@rollup/rollup-win32-x64-msvc@4.50.2':
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -9753,7 +10003,7 @@ snapshots:
   '@stylistic/eslint-plugin@5.3.1(eslint@9.35.0(jiti@2.5.1))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/types': 8.44.0
       eslint: 9.35.0(jiti@2.5.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -9761,6 +10011,11 @@ snapshots:
       picomatch: 4.0.3
 
   '@tootallnate/once@1.1.2': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -9798,11 +10053,11 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
 
   '@types/hast@3.0.4':
     dependencies:
@@ -9822,7 +10077,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
 
   '@types/linkify-it@5.0.0': {}
 
@@ -9845,9 +10100,9 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.3.3':
+  '@types/node@24.5.1':
     dependencies:
-      undici-types: 7.10.0
+      undici-types: 7.12.0
 
   '@types/prettier@2.7.3': {}
 
@@ -9865,14 +10120,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.43.0
-      '@typescript-eslint/type-utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.43.0
+      '@typescript-eslint/parser': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.44.0
+      '@typescript-eslint/type-utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.44.0
       eslint: 9.35.0(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
@@ -9882,41 +10137,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.43.0
-      '@typescript-eslint/types': 8.43.0
-      '@typescript-eslint/typescript-estree': 8.43.0(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.43.0
+      '@typescript-eslint/scope-manager': 8.44.0
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.44.0
       debug: 4.4.3
       eslint: 9.35.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.43.0(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.44.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.44.0
       debug: 4.4.3
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.43.0':
+  '@typescript-eslint/scope-manager@8.44.0':
     dependencies:
-      '@typescript-eslint/types': 8.43.0
-      '@typescript-eslint/visitor-keys': 8.43.0
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/visitor-keys': 8.44.0
 
-  '@typescript-eslint/tsconfig-utils@8.43.0(typescript@5.8.3)':
+  '@typescript-eslint/tsconfig-utils@8.44.0(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/types': 8.43.0
-      '@typescript-eslint/typescript-estree': 8.43.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       debug: 4.4.3
       eslint: 9.35.0(jiti@2.5.1)
       ts-api-utils: 2.1.0(typescript@5.8.3)
@@ -9924,14 +10179,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.43.0': {}
+  '@typescript-eslint/types@8.44.0': {}
 
-  '@typescript-eslint/typescript-estree@8.43.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.44.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.43.0(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@5.8.3)
-      '@typescript-eslint/types': 8.43.0
-      '@typescript-eslint/visitor-keys': 8.43.0
+      '@typescript-eslint/project-service': 8.44.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.8.3)
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/visitor-keys': 8.44.0
       debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -9942,27 +10197,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
-      '@typescript-eslint/scope-manager': 8.43.0
-      '@typescript-eslint/types': 8.43.0
-      '@typescript-eslint/typescript-estree': 8.43.0(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.44.0
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.8.3)
       eslint: 9.35.0(jiti@2.5.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.43.0':
+  '@typescript-eslint/visitor-keys@8.44.0':
     dependencies:
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/types': 8.44.0
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@uni-helper/plugin-uni@0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
+  '@uni-helper/plugin-uni@0.1.0(@dcloudio/vite-plugin-uni@3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
     dependencies:
-      '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001(@vueuse/core@12.8.2(typescript@5.9.2))(postcss@8.5.6)(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
   '@uni-helper/uni-app-types@1.0.0-alpha.6(typescript@5.8.3)(vue@3.4.38(typescript@5.8.3))':
     dependencies:
@@ -9973,21 +10228,21 @@ snapshots:
     dependencies:
       std-env: 3.9.0
 
-  '@uni-helper/unocss-preset-uni@0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
+  '@uni-helper/unocss-preset-uni@0.2.11(@unocss/preset-legacy-compat@66.5.1)(@unocss/preset-mini@66.5.1)(@unocss/rule-utils@66.5.1)(@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))(unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))))(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))':
     dependencies:
       '@uni-helper/uni-env': 0.1.8
       '@unocss/preset-legacy-compat': 66.5.1
       '@unocss/rule-utils': 66.5.1
-      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
-      unocss-applet: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
+      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      unocss-applet: 0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)))
     optionalDependencies:
       '@unocss/preset-mini': 66.5.1
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
-  '@uni-helper/vite-plugin-uni-components@0.2.0(rollup@4.50.1)':
+  '@uni-helper/vite-plugin-uni-components@0.2.0(rollup@4.50.2)':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       chokidar: 3.6.0
       debug: 4.4.3
       fast-glob: 3.3.3
@@ -9999,14 +10254,14 @@ snapshots:
       - rollup
       - supports-color
 
-  '@uni-helper/vite-plugin-uni-manifest@0.2.8(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))':
+  '@uni-helper/vite-plugin-uni-manifest@0.2.8(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       c12: 2.0.4
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - magicast
 
-  '@uni-helper/vite-plugin-uni-pages@0.3.11(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))':
+  '@uni-helper/vite-plugin-uni-pages@0.3.14(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       '@babel/generator': 7.28.3
       '@babel/types': 7.28.4
@@ -10025,7 +10280,7 @@ snapshots:
       magic-string: 0.30.19
       typescript: 5.9.2
       unconfig: 7.3.3
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
       yaml: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -10046,13 +10301,13 @@ snapshots:
       '@unocss/core': 66.5.1
       magic-string: 0.30.19
 
-  '@unocss/astro@66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@unocss/astro@66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@unocss/core': 66.0.0
       '@unocss/reset': 66.0.0
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - vue
 
@@ -10210,7 +10465,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.0.0
 
-  '@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@unocss/vite@66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.0.0
@@ -10220,53 +10475,53 @@ snapshots:
       magic-string: 0.30.19
       tinyglobby: 0.2.15
       unplugin-utils: 0.2.5
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - vue
 
-  '@vitejs/plugin-legacy@5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))':
+  '@vitejs/plugin-legacy@5.3.2(terser@5.44.0)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/preset-env': 7.28.3(@babel/core@7.28.4)
-      browserslist: 4.26.0
-      browserslist-to-esbuild: 2.1.1(browserslist@4.26.0)
+      browserslist: 4.26.2
+      browserslist-to-esbuild: 2.1.1(browserslist@4.26.2)
       core-js: 3.45.1
       magic-string: 0.30.19
       regenerator-runtime: 0.14.1
       systemjs: 6.15.1
       terser: 5.44.0
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.1.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))':
     dependencies:
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
 
-  '@vitest/eslint-plugin@1.3.9(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0))':
+  '@vitest/eslint-plugin@1.3.12(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0))':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.43.0
-      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.44.0
+      '@typescript-eslint/utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint: 9.35.0(jiti@2.5.1)
     optionalDependencies:
       typescript: 5.8.3
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10278,13 +10533,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@24.3.3)(terser@5.44.0))':
+  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@24.5.1)(terser@5.44.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10551,16 +10806,16 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@xiaohe01/eslint-config@2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0))':
+  '@xiaohe01/eslint-config@2.3.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.35.0(jiti@2.5.1))
       '@eslint/markdown': 7.2.0
       '@stylistic/eslint-plugin': 5.3.1(eslint@9.35.0(jiti@2.5.1))
-      '@typescript-eslint/eslint-plugin': 8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
-      '@vitest/eslint-plugin': 1.3.9(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0))
+      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@vitest/eslint-plugin': 1.3.12(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0))
       ansis: 4.1.0
       cac: 6.7.14
       eslint: 9.35.0(jiti@2.5.1)
@@ -10572,15 +10827,15 @@ snapshots:
       eslint-plugin-import-lite: 0.3.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint-plugin-jsdoc: 54.7.0(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-jsonc: 2.20.1(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-n: 17.22.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint-plugin-n: 17.23.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint-plugin-no-only-tests: 3.3.0
       eslint-plugin-perfectionist: 4.15.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint-plugin-pnpm: 1.1.1(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-regexp: 2.10.0(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-toml: 0.12.0(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-unicorn: 61.0.2(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))
-      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1)))
+      eslint-plugin-unused-imports: 4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1)))
       eslint-plugin-yml: 1.18.0(eslint@9.35.0(jiti@2.5.1))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))
       globals: 16.4.0
@@ -10734,8 +10989,8 @@ snapshots:
 
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
-      caniuse-lite: 1.0.30001741
+      browserslist: 4.26.2
+      caniuse-lite: 1.0.30001743
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -10832,7 +11087,7 @@ snapshots:
 
   base64url@3.0.1: {}
 
-  baseline-browser-mapping@2.8.3: {}
+  baseline-browser-mapping@2.8.4: {}
 
   binary-extensions@2.3.0: {}
 
@@ -10874,18 +11129,18 @@ snapshots:
 
   browser-process-hrtime@1.0.0: {}
 
-  browserslist-to-esbuild@2.1.1(browserslist@4.26.0):
+  browserslist-to-esbuild@2.1.1(browserslist@4.26.2):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       meow: 13.2.0
 
-  browserslist@4.26.0:
+  browserslist@4.26.2:
     dependencies:
-      baseline-browser-mapping: 2.8.3
-      caniuse-lite: 1.0.30001741
-      electron-to-chromium: 1.5.218
+      baseline-browser-mapping: 2.8.4
+      caniuse-lite: 1.0.30001743
+      electron-to-chromium: 1.5.219
       node-releases: 2.0.21
-      update-browserslist-db: 1.1.3(browserslist@4.26.0)
+      update-browserslist-db: 1.1.3(browserslist@4.26.2)
 
   bser@2.1.1:
     dependencies:
@@ -10906,7 +11161,7 @@ snapshots:
     dependencies:
       ansis: 4.1.0
       args-tokenizer: 0.3.0
-      c12: 3.2.0
+      c12: 3.3.0
       cac: 6.7.14
       escalade: 3.2.0
       jsonc-parser: 3.3.1
@@ -10939,7 +11194,7 @@ snapshots:
       pkg-types: 1.3.1
       rc9: 2.1.2
 
-  c12@3.2.0:
+  c12@3.3.0:
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.2
@@ -10950,7 +11205,7 @@ snapshots:
       jiti: 2.5.1
       ohash: 2.0.11
       pathe: 2.0.3
-      perfect-debounce: 1.0.0
+      perfect-debounce: 2.0.0
       pkg-types: 2.3.0
       rc9: 2.1.2
 
@@ -10958,8 +11213,11 @@ snapshots:
 
   cac@6.7.9: {}
 
-  cacheable@1.10.4:
+  cacheable@2.0.1:
     dependencies:
+      '@cacheable/memoize': 2.0.1
+      '@cacheable/memory': 2.0.1
+      '@cacheable/utils': 2.0.1
       hookified: 1.12.0
       keyv: 5.5.1
 
@@ -10981,12 +11239,12 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.26.0
-      caniuse-lite: 1.0.30001741
+      browserslist: 4.26.2
+      caniuse-lite: 1.0.30001743
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001741: {}
+  caniuse-lite@1.0.30001743: {}
 
   ccount@2.0.1: {}
 
@@ -11059,10 +11317,10 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
-  cli-truncate@4.0.0:
+  cli-truncate@5.1.0:
     dependencies:
-      slice-ansi: 5.0.0
-      string-width: 7.2.0
+      slice-ansi: 7.1.2
+      string-width: 8.1.0
 
   cliui@7.0.4:
     dependencies:
@@ -11144,7 +11402,7 @@ snapshots:
 
   core-js-compat@3.45.1:
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
 
   core-js@3.45.1: {}
 
@@ -11211,7 +11469,7 @@ snapshots:
 
   cssnano-preset-default@7.0.9(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       css-declaration-sorter: 7.2.0(postcss@8.5.6)
       cssnano-utils: 5.0.1(postcss@8.5.6)
       postcss: 8.5.6
@@ -11383,7 +11641,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.218: {}
+  electron-to-chromium@1.5.219: {}
 
   emittery@0.8.1: {}
 
@@ -11412,7 +11670,7 @@ snapshots:
 
   environment@1.1.0: {}
 
-  error-ex@1.3.2:
+  error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
 
@@ -11584,7 +11842,7 @@ snapshots:
   eslint-plugin-import-lite@0.3.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/types': 8.44.0
       eslint: 9.35.0(jiti@2.5.1)
     optionalDependencies:
       typescript: 5.8.3
@@ -11619,7 +11877,7 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@17.22.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
+  eslint-plugin-n@17.23.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
       enhanced-resolve: 5.18.3
@@ -11638,8 +11896,8 @@ snapshots:
 
   eslint-plugin-perfectionist@4.15.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/types': 8.43.0
-      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/utils': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint: 9.35.0(jiti@2.5.1)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
@@ -11699,13 +11957,13 @@ snapshots:
       semver: 7.7.2
       strip-indent: 4.1.0
 
-  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)):
+  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       eslint: 9.35.0(jiti@2.5.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
 
-  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1))):
+  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.5.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0(jiti@2.5.1))
       eslint: 9.35.0(jiti@2.5.1)
@@ -11716,7 +11974,7 @@ snapshots:
       vue-eslint-parser: 10.2.0(eslint@9.35.0(jiti@2.5.1))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
 
   eslint-plugin-yml@1.18.0(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
@@ -11847,7 +12105,7 @@ snapshots:
       is-plain-obj: 4.1.0
       is-stream: 4.0.1
       npm-run-path: 6.0.0
-      pretty-ms: 9.2.0
+      pretty-ms: 9.3.0
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
@@ -11951,7 +12209,7 @@ snapshots:
 
   file-entry-cache@10.1.4:
     dependencies:
-      flat-cache: 6.1.13
+      flat-cache: 6.1.14
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -11997,16 +12255,16 @@ snapshots:
     dependencies:
       magic-string: 0.30.19
       mlly: 1.8.0
-      rollup: 4.50.1
+      rollup: 4.50.2
 
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.3.3
       keyv: 4.5.4
 
-  flat-cache@6.1.13:
+  flat-cache@6.1.14:
     dependencies:
-      cacheable: 1.10.4
+      cacheable: 2.0.1
       flatted: 3.3.3
       hookified: 1.12.0
 
@@ -12045,7 +12303,7 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@11.3.1:
+  fs-extra@11.3.2:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
@@ -12121,7 +12379,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.4
       node-fetch-native: 1.6.7
-      nypm: 0.6.1
+      nypm: 0.6.2
       pathe: 2.0.3
 
   github-slugger@2.0.0: {}
@@ -12354,8 +12612,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@4.0.0: {}
-
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.4.0
@@ -12450,7 +12706,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -12546,7 +12802,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -12561,7 +12817,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -12571,7 +12827,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12590,7 +12846,7 @@ snapshots:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -12633,7 +12889,7 @@ snapshots:
   jest-mock@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
 
   jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     optionalDependencies:
@@ -12669,7 +12925,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -12720,7 +12976,7 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
@@ -12753,7 +13009,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12772,7 +13028,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -12780,7 +13036,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -12948,7 +13204,7 @@ snapshots:
       commander: 14.0.1
       debug: 4.4.3
       lilconfig: 3.1.3
-      listr2: 9.0.3
+      listr2: 9.0.4
       micromatch: 4.0.8
       nano-spawn: 1.0.3
       pidtree: 0.6.0
@@ -12957,9 +13213,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  listr2@9.0.3:
+  listr2@9.0.4:
     dependencies:
-      cli-truncate: 4.0.0
+      cli-truncate: 5.1.0
       colorette: 2.0.20
       eventemitter3: 5.0.1
       log-update: 6.1.0
@@ -13038,6 +13294,16 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-regexp@0.10.0:
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+      mlly: 1.8.0
+      regexp-tree: 0.1.27
+      type-level-regexp: 0.1.17
+      ufo: 1.6.1
+      unplugin: 2.3.10
 
   magic-string@0.30.19:
     dependencies:
@@ -13470,7 +13736,7 @@ snapshots:
 
   miniprogram-api-typings@4.1.0: {}
 
-  minisearch@7.1.2: {}
+  minisearch@7.2.0: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -13485,7 +13751,7 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mkdist@2.4.1(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
+  mkdist@2.3.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.6)
       citty: 0.1.6
@@ -13566,7 +13832,7 @@ snapshots:
       tinyexec: 0.3.2
       ufo: 1.6.1
 
-  nypm@0.6.1:
+  nypm@0.6.2:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
@@ -13627,6 +13893,31 @@ snapshots:
   os-locale-s-fix@1.0.8-fix-1:
     dependencies:
       lcid: 3.1.1
+
+  oxc-parser@0.89.0:
+    dependencies:
+      '@oxc-project/types': 0.89.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm64': 0.89.0
+      '@oxc-parser/binding-darwin-arm64': 0.89.0
+      '@oxc-parser/binding-darwin-x64': 0.89.0
+      '@oxc-parser/binding-freebsd-x64': 0.89.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.89.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.89.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.89.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.89.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.89.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.89.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.89.0
+      '@oxc-parser/binding-linux-x64-musl': 0.89.0
+      '@oxc-parser/binding-wasm32-wasi': 0.89.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.89.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.89.0
+
+  oxc-walker@0.5.2(oxc-parser@0.89.0):
+    dependencies:
+      magic-regexp: 0.10.0
+      oxc-parser: 0.89.0
 
   p-limit@2.3.0:
     dependencies:
@@ -13694,7 +13985,7 @@ snapshots:
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.27.1
-      error-ex: 1.3.2
+      error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
@@ -13736,6 +14027,8 @@ snapshots:
   pathval@2.0.1: {}
 
   perfect-debounce@1.0.0: {}
+
+  perfect-debounce@2.0.0: {}
 
   phin@2.9.3: {}
 
@@ -13818,7 +14111,7 @@ snapshots:
 
   postcss-colormin@7.0.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.6
@@ -13826,7 +14119,7 @@ snapshots:
 
   postcss-convert-values@7.0.7(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
@@ -13878,7 +14171,7 @@ snapshots:
 
   postcss-merge-rules@7.0.6(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       caniuse-api: 3.0.0
       cssnano-utils: 5.0.1(postcss@8.5.6)
       postcss: 8.5.6
@@ -13898,7 +14191,7 @@ snapshots:
 
   postcss-minify-params@7.0.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       cssnano-utils: 5.0.1(postcss@8.5.6)
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
@@ -13978,7 +14271,7 @@ snapshots:
 
   postcss-normalize-unicode@7.0.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
@@ -14000,7 +14293,7 @@ snapshots:
 
   postcss-reduce-initial@7.0.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       caniuse-api: 3.0.0
       postcss: 8.5.6
 
@@ -14060,6 +14353,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-bytes@6.1.1: {}
+
   pretty-bytes@7.0.1: {}
 
   pretty-format@27.5.1:
@@ -14068,7 +14363,7 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  pretty-ms@9.2.0:
+  pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
 
@@ -14257,39 +14552,39 @@ snapshots:
       glob: 11.0.3
       package-json-from-dist: 1.0.1
 
-  rollup-plugin-dts@6.2.3(rollup@4.50.1)(typescript@5.8.3):
+  rollup-plugin-dts@6.2.3(rollup@4.50.2)(typescript@5.8.3):
     dependencies:
       magic-string: 0.30.19
-      rollup: 4.50.1
+      rollup: 4.50.2
       typescript: 5.8.3
     optionalDependencies:
       '@babel/code-frame': 7.27.1
 
-  rollup@4.50.1:
+  rollup@4.50.2:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.50.1
-      '@rollup/rollup-android-arm64': 4.50.1
-      '@rollup/rollup-darwin-arm64': 4.50.1
-      '@rollup/rollup-darwin-x64': 4.50.1
-      '@rollup/rollup-freebsd-arm64': 4.50.1
-      '@rollup/rollup-freebsd-x64': 4.50.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.50.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.50.1
-      '@rollup/rollup-linux-arm64-gnu': 4.50.1
-      '@rollup/rollup-linux-arm64-musl': 4.50.1
-      '@rollup/rollup-linux-loongarch64-gnu': 4.50.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.50.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.50.1
-      '@rollup/rollup-linux-riscv64-musl': 4.50.1
-      '@rollup/rollup-linux-s390x-gnu': 4.50.1
-      '@rollup/rollup-linux-x64-gnu': 4.50.1
-      '@rollup/rollup-linux-x64-musl': 4.50.1
-      '@rollup/rollup-openharmony-arm64': 4.50.1
-      '@rollup/rollup-win32-arm64-msvc': 4.50.1
-      '@rollup/rollup-win32-ia32-msvc': 4.50.1
-      '@rollup/rollup-win32-x64-msvc': 4.50.1
+      '@rollup/rollup-android-arm-eabi': 4.50.2
+      '@rollup/rollup-android-arm64': 4.50.2
+      '@rollup/rollup-darwin-arm64': 4.50.2
+      '@rollup/rollup-darwin-x64': 4.50.2
+      '@rollup/rollup-freebsd-arm64': 4.50.2
+      '@rollup/rollup-freebsd-x64': 4.50.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.50.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.50.2
+      '@rollup/rollup-linux-arm64-gnu': 4.50.2
+      '@rollup/rollup-linux-arm64-musl': 4.50.2
+      '@rollup/rollup-linux-loong64-gnu': 4.50.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.50.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.50.2
+      '@rollup/rollup-linux-riscv64-musl': 4.50.2
+      '@rollup/rollup-linux-s390x-gnu': 4.50.2
+      '@rollup/rollup-linux-x64-gnu': 4.50.2
+      '@rollup/rollup-linux-x64-musl': 4.50.2
+      '@rollup/rollup-openharmony-arm64': 4.50.2
+      '@rollup/rollup-win32-arm64-msvc': 4.50.2
+      '@rollup/rollup-win32-ia32-msvc': 4.50.2
+      '@rollup/rollup-win32-x64-msvc': 4.50.2
       fsevents: 2.3.3
 
   run-applescript@7.1.0: {}
@@ -14433,11 +14728,6 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  slice-ansi@5.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 4.0.0
-
   slice-ansi@7.1.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -14506,6 +14796,11 @@ snapshots:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
 
+  string-width@8.1.0:
+    dependencies:
+      get-east-asian-width: 1.4.0
+      strip-ansi: 7.1.2
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -14537,7 +14832,7 @@ snapshots:
 
   stylehacks@7.0.6(postcss@8.5.6):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
@@ -14756,6 +15051,9 @@ snapshots:
 
   tslib@2.3.0: {}
 
+  tslib@2.8.1:
+    optional: true
+
   tsx@4.20.5:
     dependencies:
       esbuild: 0.25.9
@@ -14776,6 +15074,8 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-level-regexp@0.1.17: {}
+
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
@@ -14788,14 +15088,14 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  unbuild@3.6.1(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
+  unbuild@3.5.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3)):
     dependencies:
-      '@rollup/plugin-alias': 5.1.1(rollup@4.50.1)
-      '@rollup/plugin-commonjs': 28.0.6(rollup@4.50.1)
-      '@rollup/plugin-json': 6.1.0(rollup@4.50.1)
-      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.50.1)
-      '@rollup/plugin-replace': 6.0.2(rollup@4.50.1)
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/plugin-alias': 5.1.1(rollup@4.50.2)
+      '@rollup/plugin-commonjs': 28.0.6(rollup@4.50.2)
+      '@rollup/plugin-json': 6.1.0(rollup@4.50.2)
+      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.50.2)
+      '@rollup/plugin-replace': 6.0.2(rollup@4.50.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -14804,13 +15104,13 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.5.1
       magic-string: 0.30.19
-      mkdist: 2.4.1(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
+      mkdist: 2.3.0(typescript@5.8.3)(vue-tsc@2.1.10(typescript@5.8.3))(vue@3.4.38(typescript@5.8.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
-      pretty-bytes: 7.0.1
-      rollup: 4.50.1
-      rollup-plugin-dts: 6.2.3(rollup@4.50.1)(typescript@5.8.3)
+      pretty-bytes: 6.1.1
+      rollup: 4.50.2
+      rollup-plugin-dts: 6.2.3(rollup@4.50.2)(typescript@5.8.3)
       scule: 1.3.0
       tinyglobby: 0.2.15
       untyped: 2.0.0
@@ -14835,18 +15135,18 @@ snapshots:
       jiti: 2.5.1
       quansync: 0.2.11
 
-  undici-types@7.10.0: {}
+  undici-types@7.12.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
     dependencies:
       unicode-canonical-property-names-ecmascript: 2.0.1
-      unicode-property-aliases-ecmascript: 2.1.0
+      unicode-property-aliases-ecmascript: 2.2.0
 
   unicode-match-property-value-ecmascript@2.2.1: {}
 
-  unicode-property-aliases-ecmascript@2.1.0: {}
+  unicode-property-aliases-ecmascript@2.2.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -14929,16 +15229,16 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))):
+  unocss-applet@0.11.0(unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))):
     dependencies:
       '@unocss-applet/preset-applet': 0.11.0
       '@unocss-applet/preset-rem-rpx': 0.11.0
       '@unocss-applet/transformer-attributify': 0.11.0
-      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      unocss: 66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
 
-  unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)):
+  unocss@66.0.0(postcss@8.5.6)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2)):
     dependencies:
-      '@unocss/astro': 66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/astro': 66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@unocss/cli': 66.0.0
       '@unocss/core': 66.0.0
       '@unocss/postcss': 66.0.0(postcss@8.5.6)
@@ -14955,9 +15255,9 @@ snapshots:
       '@unocss/transformer-compile-class': 66.0.0
       '@unocss/transformer-directives': 66.0.0
       '@unocss/transformer-variant-group': 66.0.0
-      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@unocss/vite': 66.0.0(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
     optionalDependencies:
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -15014,9 +15314,9 @@ snapshots:
       knitwork: 1.2.0
       scule: 1.3.0
 
-  update-browserslist-db@1.1.3(browserslist@4.26.0):
+  update-browserslist-db@1.1.3(browserslist@4.26.2):
     dependencies:
-      browserslist: 4.26.0
+      browserslist: 4.26.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -15055,13 +15355,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.3.3)(terser@5.44.0):
+  vite-node@3.2.4(@types/node@24.5.1)(terser@5.44.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15073,42 +15373,42 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-inspect@0.8.9(rollup@4.50.1)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)):
+  vite-plugin-inspect@0.8.9(rollup@4.50.2)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
       debug: 4.4.3
       error-stack-parser-es: 0.1.5
-      fs-extra: 11.3.1
+      fs-extra: 11.3.2
       open: 10.2.0
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.2
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
   vite-plugin-uni-polyfill@0.1.0: {}
 
-  vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0):
+  vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
-      rollup: 4.50.1
+      rollup: 4.50.2
     optionalDependencies:
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       fsevents: 2.3.3
       sass: 1.78.0
       terser: 5.44.0
 
-  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)):
+  vitepress-plugin-group-icons@1.6.3(markdown-it@14.1.0)(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)):
     dependencies:
       '@iconify-json/logos': 1.2.9
       '@iconify-json/vscode-icons': 1.2.30
-      '@iconify/utils': 3.0.1
+      '@iconify/utils': 3.0.2
       markdown-it: 14.1.0
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15130,25 +15430,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.6.4(@algolia/client-search@5.37.0)(@types/node@24.3.3)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2):
+  vitepress@1.6.4(@algolia/client-search@5.37.0)(@types/node@24.5.1)(change-case@5.4.4)(postcss@8.5.6)(sass@1.78.0)(search-insights@2.17.3)(terser@5.44.0)(typescript@5.9.2):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.37.0)(search-insights@2.17.3)
-      '@iconify-json/simple-icons': 1.2.51
+      '@iconify-json/simple-icons': 1.2.52
       '@shikijs/core': 2.5.0
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0))(vue@3.4.38(typescript@5.9.2))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.21
       '@vueuse/core': 12.8.2(typescript@5.9.2)
       '@vueuse/integrations': 12.8.2(change-case@5.4.4)(focus-trap@7.6.5)(typescript@5.9.2)
       focus-trap: 7.6.5
       mark.js: 8.11.1
-      minisearch: 7.1.2
+      minisearch: 7.2.0
       shiki: 2.5.0
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
       vue: 3.4.38(typescript@5.9.2)
     optionalDependencies:
       postcss: 8.5.6
@@ -15179,11 +15479,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.3)(jsdom@16.7.0)(terser@5.44.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.5.1)(jsdom@16.7.0)(terser@5.44.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@24.3.3)(terser@5.44.0))
+      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@24.5.1)(terser@5.44.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -15201,12 +15501,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.20(@types/node@24.3.3)(sass@1.78.0)(terser@5.44.0)
-      vite-node: 3.2.4(@types/node@24.3.3)(terser@5.44.0)
+      vite: 5.4.20(@types/node@24.5.1)(sass@1.78.0)(terser@5.44.0)
+      vite-node: 3.2.4(@types/node@24.5.1)(terser@5.44.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.3.3
+      '@types/node': 24.5.1
       jsdom: 16.7.0
     transitivePeerDependencies:
       - less

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - packages/**
   - examples/**
 overrides:
+  '@types/node': 22.18.6
   mkdist: 2.3.0
   vue: 3.4.38
 catalogs:
@@ -65,7 +66,7 @@ catalogs:
     '@xiaohe01/eslint-config': ^2.3.0
     '@xiaohe01/stylelint-config': ^2.4.0
     eslint: ^9.36.0
-    lint-staged: ^16.1.6
+    lint-staged: ^16.2.0
     simple-git-hooks: ^2.13.1
     stylelint: ^16.24.0
   node:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,9 +8,9 @@ overrides:
   vue: 3.4.38
 catalogs:
   build:
-    '@uni-helper/vite-plugin-uni-components': ^0.2.0
+    '@uni-helper/vite-plugin-uni-components': ^0.2.1
     '@uni-helper/vite-plugin-uni-manifest': ^0.2.8
-    '@uni-helper/vite-plugin-uni-pages': ^0.3.14
+    '@uni-helper/vite-plugin-uni-pages': ^0.3.15
     unbuild: ~3.5.0
     unplugin-auto-import: ^20.1.0
     vite: ^5.4.20
@@ -44,13 +44,13 @@ catalogs:
     '@dcloudio/uni-stacktracey': 3.0.0-4070620250821001
     '@dcloudio/vite-plugin-uni': 3.0.0-4070620250821001
   dev:
-    '@antfu/ni': ^25.0.0
+    '@antfu/ni': ^26.0.1
     '@mini-types/alipay': ^3.0.14
     '@uni-helper/plugin-uni': ^0.1.0
     '@uni-helper/uni-app-types': ^1.0.0-alpha.6
     '@xiaohe01/tsconfig': ^2.0.0
     miniprogram-api-typings: ^4.1.0
-    oxc-parser: ^0.89.0
+    oxc-parser: ^0.90.0
     typescript: ~5.8.3
   frontend:
     '@vue/runtime-core': ~3.4.38
@@ -64,7 +64,7 @@ catalogs:
   lint:
     '@xiaohe01/eslint-config': ^2.3.0
     '@xiaohe01/stylelint-config': ^2.4.0
-    eslint: ^9.35.0
+    eslint: ^9.36.0
     lint-staged: ^16.1.6
     simple-git-hooks: ^2.13.1
     stylelint: ^16.24.0
@@ -87,7 +87,7 @@ catalogs:
     '@types/fs-extra': ^11.0.4
     '@types/lodash-es': ^4.17.12
   utils:
-    '@antfu/utils': ^9.2.0
+    '@antfu/utils': ^9.2.1
     '@vueuse/core': ^12.8.2
     lodash-es: ^4.17.21
 onlyBuiltDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,19 +9,20 @@ catalogs:
   build:
     '@uni-helper/vite-plugin-uni-components': ^0.2.0
     '@uni-helper/vite-plugin-uni-manifest': ^0.2.8
-    '@uni-helper/vite-plugin-uni-pages': ^0.3.9
-    unbuild: ~3.5.0
+    '@uni-helper/vite-plugin-uni-pages': ^0.3.11
+    unbuild: ~3.6.1
     unplugin-auto-import: ^20.1.0
-    vite: ^5.4.19
+    vite: ^5.4.20
+    vite-plugin-inspect: ~0.8.9
     vite-plugin-uni-polyfill: ^0.1.0
     vitepress: ^1.6.4
     vitepress-plugin-group-icons: ^1.6.3
-    vitepress-plugin-llms: ^1.7.3
+    vitepress-plugin-llms: ^1.7.5
   cli:
     bumpp: ^10.2.3
-    pncat: ^0.5.3
+    pncat: ^0.5.4
   dcloudio:
-    '@dcloudio/types': ^3.4.19
+    '@dcloudio/types': ^3.4.21
     '@dcloudio/uni-app': 3.0.0-4070620250821001
     '@dcloudio/uni-app-harmony': 3.0.0-4070620250821001
     '@dcloudio/uni-app-plus': 3.0.0-4070620250821001
@@ -59,14 +60,14 @@ catalogs:
   icons:
     '@iconify-json/carbon': ^1.2.13
   lint:
-    '@xiaohe01/eslint-config': ^2.2.2
+    '@xiaohe01/eslint-config': ^2.3.0
     '@xiaohe01/stylelint-config': ^2.4.0
-    eslint: ^9.34.0
+    eslint: ^9.35.0
     lint-staged: ^16.1.6
     simple-git-hooks: ^2.13.1
-    stylelint: ^16.23.1
+    stylelint: ^16.24.0
   node:
-    chalk: ^5.6.0
+    chalk: ^5.6.2
     consola: ^3.4.2
     execa: ^9.6.0
     fs-extra: ^11.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,7 @@ catalogs:
   types:
     '@types/fs-extra': ^11.0.4
     '@types/lodash-es': ^4.17.12
+    '@types/node': ^22.18.6
   utils:
     '@antfu/utils': ^9.2.1
     '@vueuse/core': ^12.8.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,6 @@ catalogs:
     '@xiaohe01/tsconfig': ^2.0.0
     miniprogram-api-typings: ^4.1.0
     oxc-parser: ^0.89.0
-    oxc-walker: ^0.5.2
     typescript: ~5.8.3
   frontend:
     '@vue/runtime-core': ~3.4.38

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,13 +4,14 @@ packages:
   - packages/**
   - examples/**
 overrides:
+  mkdist: 2.3.0
   vue: 3.4.38
 catalogs:
   build:
     '@uni-helper/vite-plugin-uni-components': ^0.2.0
     '@uni-helper/vite-plugin-uni-manifest': ^0.2.8
-    '@uni-helper/vite-plugin-uni-pages': ^0.3.11
-    unbuild: ~3.6.1
+    '@uni-helper/vite-plugin-uni-pages': ^0.3.14
+    unbuild: ~3.5.0
     unplugin-auto-import: ^20.1.0
     vite: ^5.4.20
     vite-plugin-inspect: ~0.8.9
@@ -49,6 +50,8 @@ catalogs:
     '@uni-helper/uni-app-types': ^1.0.0-alpha.6
     '@xiaohe01/tsconfig': ^2.0.0
     miniprogram-api-typings: ^4.1.0
+    oxc-parser: ^0.89.0
+    oxc-walker: ^0.5.2
     typescript: ~5.8.3
   frontend:
     '@vue/runtime-core': ~3.4.38
@@ -70,7 +73,7 @@ catalogs:
     chalk: ^5.6.2
     consola: ^3.4.2
     execa: ^9.6.0
-    fs-extra: ^11.3.1
+    fs-extra: ^11.3.2
     rimraf: ^6.0.1
   script:
     esno: ^4.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,9 @@ overrides:
   vue: 3.4.38
 catalogs:
   build:
+    '@rollup/plugin-commonjs': ^28.0.6
+    '@rollup/plugin-node-resolve': ^16.0.1
+    '@rollup/plugin-terser': ^0.4.4
     '@uni-helper/vite-plugin-uni-components': ^0.2.1
     '@uni-helper/vite-plugin-uni-manifest': ^0.2.8
     '@uni-helper/vite-plugin-uni-pages': ^0.3.15
@@ -50,6 +53,7 @@ catalogs:
     '@uni-helper/plugin-uni': ^0.1.0
     '@uni-helper/uni-app-types': ^1.0.0-alpha.6
     '@xiaohe01/tsconfig': ^2.0.0
+    minimist: ^1.2.8
     miniprogram-api-typings: ^4.1.0
     oxc-parser: ^0.90.0
     typescript: ~5.8.3
@@ -70,6 +74,7 @@ catalogs:
     simple-git-hooks: ^2.13.1
     stylelint: ^16.24.0
   node:
+    '@clack/prompts': ^0.11.0
     chalk: ^5.6.2
     consola: ^3.4.2
     execa: ^9.6.0
@@ -87,6 +92,7 @@ catalogs:
   types:
     '@types/fs-extra': ^11.0.4
     '@types/lodash-es': ^4.17.12
+    '@types/minimist': ^1.2.5
     '@types/node': ^22.18.6
   utils:
     '@antfu/utils': ^9.2.1


### PR DESCRIPTION
- [x] 🚀 新增 Vite 插件自动化处理繁琐任务
- [x] 🚀 支持使用定制 echarts.min.js
- [x] 🚀 新增 cli 用于转换 echarts.min.js 为 esm 模块
- [x] 🚨 uni-modules 方式的 `provideEcharts` 调整为必须调用
- [x] 📄 文档新增定制 echarts.min.js 使用指引
- [x] 📄 文档新增 2.x 迁移说明