### PR TITLE
fix: fallback to clientX/clientY in transformTouchesEvent for gesture recognition

### DIFF
--- a/packages/shared/src/composables/useEchartsTouch.ts
+++ b/packages/shared/src/composables/useEchartsTouch.ts
@@ -96,9 +96,9 @@ export function useEchartsTouch({
       const item = event.touches[i];
 
       // @ts-expect-error whatever
-      item.offsetX = item.x;
+      item.offsetX = item.x ?? (item.clientX - canvasRect.left);
       // @ts-expect-error whatever
-      item.offsetY = item.y;
+      item.offsetY = item.y ?? (item.clientY - canvasRect.top);
     }
 
     return event;

--- a/packages/shared/src/composables/useEchartsTouch.ts
+++ b/packages/shared/src/composables/useEchartsTouch.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter, Reactive, Ref } from "vue";
 import { shallowRef, toValue } from "vue";
 import type { EChartsType, NullableValue } from "../types";
-import { querySelect, UniCanvas } from "../utils";
+import { defaultTo, querySelect, UniCanvas } from "../utils";
 import type { VueThis } from "./useVueThis";
 
 export interface CanvasRect {
@@ -96,9 +96,9 @@ export function useEchartsTouch({
       const item = event.touches[i];
 
       // @ts-expect-error whatever
-      item.offsetX = item.x ?? (item.clientX - canvasRect.left);
+      item.offsetX = defaultTo(item.x, item.clientX - canvasRect.left);
       // @ts-expect-error whatever
-      item.offsetY = item.y ?? (item.clientY - canvasRect.top);
+      item.offsetY = defaultTo(item.y, item.clientY - canvasRect.top);
     }
 
     return event;


### PR DESCRIPTION
## 问题描述
Closes #53 
在支付宝小程序中，由于 `isMpAlipay` 为 `true`，组件会渲染一个 mask `<view>` 覆盖在 canvas 上方来接收触摸事件。

当用户在 mask `<view>` 上进行双指缩放手势时，触摸事件的 touch 对象可能不包含 `x`/`y` 属性（这些属性是相对于 canvas 的坐标，view 元素上不一定有）。此时 `transformTouchesEvent` 中 `item.offsetX = item.x` 会导致 `offsetX` 为 `undefined`，使得 ZRender 的 `processGesture` 无法正确计算双指间距，导致 dataZoom 的 `type: "inside"` 缩放手势完全失效。

### 复现步骤

1. 在支付宝小程序中使用 `uni-echarts` 组件
2. 配置 `dataZoom: [{ type: "inside" }]`
3. 双指捏合缩放 ❌ 无响应

## 原因分析

`transformTouchesEvent` 直接使用 `item.x`/`item.y` 设置 `offsetX`/`offsetY`，没有像 `getTouch`/`getRelativeTouch` 那样提供 `clientX`/`clientY` 的 fallback 处理：

// 之前
item.offsetX = item.x;          // mask <view> 上 item.x 可能是 undefined
item.offsetY = item.y;
// 修改后
item.offsetX = item.x ?? (item.clientX - canvasRect.left);
item.offsetY = item.y ?? (item.clientY - canvasRect.top);

## 修改摘要

本次只修改了 `packages/shared/src/composables/useEchartsTouch.ts` 中 `transformTouchesEvent` 函数的两行代码，为 `offsetX`/`offsetY` 赋值增加了 `clientX`/`clientY` 的 fallback，与组件中已有的 `getRelativeTouch` 逻辑保持一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了触摸事件的坐标计算：在原始坐标不可用时会回退为相对于画布的客户端坐标，提升跨设备与浏览器的兼容性与触控交互的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->